### PR TITLE
PID Binding

### DIFF
--- a/archivematicaselenium.py
+++ b/archivematicaselenium.py
@@ -2826,6 +2826,11 @@ class ArchivematicaSelenium:
             input_el = self.driver.find_element_by_id(dom_id)
             if input_el.tag_name == 'select':
                 Select(input_el).select_by_visible_text(val)
+            elif input_el.get_attribute('type') == 'checkbox':
+                state = input_el.get_attribute('checked')
+                if ((val is True and state != 'true') or
+                        (val is False and state == 'true')):
+                    input_el.click()
             else:
                 input_el.clear()
                 input_el.send_keys(val)

--- a/features/core/ingest-mkv-conformance.feature
+++ b/features/core/ingest-mkv-conformance.feature
@@ -21,6 +21,7 @@ Feature: Ingest (i.e., post-normalization) conformance check
     When the user chooses "Approve" at decision point "Approve normalization (review)" during ingest
     And the user waits for the "Store AIP (review)" decision point to appear during ingest
     Then all PREMIS implementation-check-type validation events have eventOutcome = <event_outcome>
+
     Examples: Normalized for Preservation File Validity Possibilities
     | file_validity | microservice_output    | validation_result | event_outcome | transfer_path                       |
     | valid         | Completed successfully | Passed            | pass          | preforma/when-normalized-all-valid  |

--- a/features/core/pid-binding.feature
+++ b/features/core/pid-binding.feature
@@ -1,0 +1,29 @@
+@pid-binding @dev
+Feature: Archivematica's entities can be assigned PIDs with specified resolution properties.
+  Users of Archivematica want to be able to generate Persistent IDentifiers
+  (PIDs)---in this case Handle System handles---for Files and SIP/DIPs (and
+  possibly also Directories) processed by Archivematica. The PIDs are based on
+  the UUIDs of the respective entity, i.e., "hdl:<NAMING_AUTHORITY>/<UUID>.
+  Archivematica should document both the PIDs and the derivable PURLs as
+  premis:objectIdentifierType in the MET file of the DIP/AIP. The user should
+  be able to configure Archivematica so that the PID URL (PURL) of an
+  Archivematica-processed entity will resolve to particular resolve URLs. In
+  addition, it should be possible to set *qualified* PURLs (e.g., with GET
+  query params appended) to resolve to distinct URLs (e.g., derivatives).
+  # NOTE: The SOAP/HTTP API that this last feature is implemented against may
+  # be highly idiosyncratic.
+
+  @typical
+  Scenario Outline: Lucien wants to create an AIP with a METS file that documents the binding of persistent identifiers to all of the AIP's original files and directories, and to the AIP itself.
+    Given a fully automated default processing config
+    And default processing configured to assign UUIDs to directories
+    And default processing configured to bind PIDs
+    And a Handle server client configured to create qualified PURLs
+    And a Handle server client configured to use the accession number as the PID for the AIP
+    When a transfer is initiated on directory <directory_path> with accession number <accession_no>
+    And the user waits for the "Store AIP (review)" decision point to appear during ingest
+    Then the AIP METS file documents PIDs, PURLs, and UUIDs for all files, directories and the package itself
+
+    Examples: transfer sources
+    | directory_path                                                                                 | accession_no |
+    | ~/archivematica-sampledata/TestTransfers/acceptance-tests/pid-binding/hierarchy-with-empty-dir | 42           |

--- a/features/core/uuids-for-directories.feature
+++ b/features/core/uuids-for-directories.feature
@@ -1,0 +1,24 @@
+@uuids-dirs @dev
+Feature: UUIDs for Directories
+  Sometimes Archivematica users want to be able to treat the directories in a
+  transfer as intellectual entities. They want to be able to assign identifiers
+  (UUIDs) to them and, ultimately, be able to assign persistent identifiers
+  (PIDs) to them, such as handles or DOIs.
+
+    Scenario Outline: Lucien wants to create an AIP where each subdirectory of the original transfer is assigned a UUID and this is recorded in the AIP's METS file.
+    Given a processing configuration that assigns UUIDs to directories
+    And remote directory <directory_path> contains a hierarchy of subfolders containing digital objects
+    When a transfer is initiated on directory <directory_path>
+    And the user waits for the "Store AIP (review)" decision point to appear during ingest
+    Then the METS file includes the original directory structure
+    And the UUIDs for the subfolders and digital objects are written to the METS file
+
+    Examples: transfer sources
+    | directory_path                                                                                 |
+    | ~/archivematica-sampledata/TestTransfers/acceptance-tests/pid-binding/hierarchy-with-empty-dir |
+
+# Possible further tests/ refinements:
+# - test with compressed packages, verify that UUIDs can be generated for all
+#   directories within one
+# - test after SIP arrange
+# - confirm sanitization of directory names is working

--- a/features/environment.py
+++ b/features/environment.py
@@ -30,23 +30,25 @@ SERVER_PASSWORD = 'vagrant'
 
 def get_am_sel_cli(userdata):
     """Instantiate an ArchivematicaSelenium."""
-    return archivematicaselenium.ArchivematicaSelenium(
-        userdata.get('am_username', AM_USERNAME),
-        userdata.get('am_password', AM_PASSWORD),
-        userdata.get('am_url', AM_URL),
-        userdata.get('am_version', AM_VERSION),
-        userdata.get('am_api_key', AM_API_KEY),
-        userdata.get('ss_username', SS_USERNAME),
-        userdata.get('ss_password', SS_PASSWORD),
-        userdata.get('ss_url', SS_URL),
-        userdata.get('ss_api_key', SS_API_KEY),
-        userdata.get('driver_name', DRIVER_NAME),
-        ssh_accessible=bool(userdata.get('ssh_accessible', SSH_ACCESSIBLE)),
-        ssh_requires_password=bool(userdata.get(
-            'ssh_requires_password', SSH_REQUIRES_PASSWORD)),
-        server_user=userdata.get('server_user', SERVER_USER),
-        server_password=userdata.get('server_password', SERVER_PASSWORD)
-    )
+    userdata.update({
+        'am_username': userdata.get('am_username', AM_USERNAME),
+        'am_password': userdata.get('am_password', AM_PASSWORD),
+        'am_url': userdata.get('am_url', AM_URL),
+        'am_version': userdata.get('am_version', AM_VERSION),
+        'am_api_key': userdata.get('am_api_key', AM_API_KEY),
+        'ss_username': userdata.get('ss_username', SS_USERNAME),
+        'ss_password': userdata.get('ss_password', SS_PASSWORD),
+        'ss_url': userdata.get('ss_url', SS_URL),
+        'ss_api_key': userdata.get('ss_api_key', SS_API_KEY),
+        'driver_name': userdata.get('driver_name', DRIVER_NAME),
+        'ssh_accessible': bool(
+            userdata.get('ssh_accessible', SSH_ACCESSIBLE)),
+        'ssh_requires_password': bool(
+            userdata.get('ssh_requires_password', SSH_REQUIRES_PASSWORD)),
+        'server_user': userdata.get('server_user', SERVER_USER),
+        'server_password': userdata.get('server_password', SERVER_PASSWORD)
+    })
+    return archivematicaselenium.ArchivematicaSelenium(**userdata)
 
 
 def before_scenario(context, scenario):

--- a/tmp.py
+++ b/tmp.py
@@ -1,0 +1,40 @@
+"""Embryonic script for getting directory structure from AIP.
+
+Note: this could be re-usable functionality: a correct API (with tests) for
+encoding a directory structure in a METS file and getting the same directory
+structure back again. Is this already in mets-reader-writer?
+"""
+
+from lxml import etree
+import os
+import pprint
+
+path = ('/Users/joeldunham/Downloads/zn-92bd2579-326d-44c1-9a72-271ad53e4266/'
+        'data/METS.92bd2579-326d-44c1-9a72-271ad53e4266.xml')
+
+# Namespace map for parsing METS XML.
+ns = {
+    'mets': 'http://www.loc.gov/METS/',
+    'premis': 'info:lc/xmlns/premis-v2',
+    'dc': 'http://purl.org/dc/elements/1.1/',
+    'dcterms': 'http://purl.org/dc/terms/',
+    'xlink': 'http://www.w3.org/1999/xlink'
+}
+
+def _get_subpaths_from_struct_map(elem, ns, base_path='', paths=None):
+    if not paths:
+        paths = set()
+    for div_el in elem.findall('mets:div', ns):
+        path = os.path.join(base_path, div_el.get('LABEL'))
+        paths.add(path)
+        for subpath in _get_subpaths_from_struct_map(
+                div_el, ns, base_path=path, paths=paths):
+            paths.add(subpath)
+    return paths
+
+with open(path) as filei:
+    mets = etree.parse(filei)
+    struct_map_el = mets.find('.//mets:structMap[@TYPE="physical"]', ns)
+    subpaths = _get_subpaths_from_struct_map(struct_map_el, ns)
+    print('got subpaths of structmap')
+    pprint.pprint(subpaths)


### PR DESCRIPTION
Feature file for PID binding and assignment of UUIDs to directories. Archivematica can be configured to make requests to a Handle System HTTP API so that files, directories and entire AIPs can be assigned persistent identifiers (PIDs) and derived persistent URLs (PURLs). See https://github.com/artefactual/archivematica/pull/690. Also requires https://github.com/artefactual/archivematica-sampledata/pull/4.

Assuming a standard Vagrant/Ansible Archivematica deploy using https://github.com/artefactual/deploy-pub, Issue the following commands to run the PID binding tests. In order for these to pass, valid values for the arguments in angle brackets must be supplied.  These values depend on the configuration of a particular Handle System HTTP API. See the implementation of the step "Given a Handle server client configured to create qualified PURLs" in features/steps/steps.py if the meaning of these arguments is unclear::

    $ cd /vagrant/src/archivematica-acceptance-tests
    $ source /usr/share/python/archivematica-acceptance-tests/bin/activate
    $ tightvncserver -geometry 1920x1080 :42
    $ export DISPLAY=:42
    $ behave \
        --tags=pid-binding \
        --no-skipped \
        -D driver_name=Firefox \
        -D am_version=1.7 \
        -D pid_web_service_endpoint=<SOME_URL> \
        -D pid_web_service_key=<SOME_RANDOM_STRING> \
        -D handle_resolver_url=<SOME_OTHER_URL> \
        -D base_resolve_url=<YET_ANOTHER_URL> \
        -D pid_xml_namespace=<PROBABLY_ANOTHER_URL>

The following commands will run the test that checks that UUIDs can be assigned to directories::

    $ cd /vagrant/src/archivematica-acceptance-tests
    $ source /usr/share/python/archivematica-acceptance-tests/bin/activate
    $ tightvncserver -geometry 1920x1080 :42
    $ export DISPLAY=:42
    $ behave \
        --tags=uuids-dirs \
        --no-skipped \
        -D driver_name=Firefox \
        -D am_version=1.7