### PR TITLE
AIP encryption via replication feature

### DIFF
--- a/archivematicaselenium.py
+++ b/archivematicaselenium.py
@@ -2326,9 +2326,22 @@ class ArchivematicaSelenium:
         search_el.send_keys('Store AIP in standard Archivematica Directory')
         row_els = self.driver.find_elements_by_css_selector(
             '#DataTables_Table_0 > tbody > tr')
-        if len(row_els) != 1:
+        if len(row_els) == 0:
             raise ArchivematicaSeleniumError(
-                'Unable to find a unique default AIP storage location')
+                'Unable to find a default AIP storage location')
+        if len(row_els) > 1:
+            new_row_els = []
+            for row_el in row_els:
+                row_text = []
+                for td_el in row_el.find_elements_by_css_selector('td'):
+                    row_text.append(td_el.text.strip().lower())
+                if 'encrypted' not in ''.join(row_text):
+                    new_row_els.append(row_el)
+            if len(new_row_els) == 1:
+                row_els = new_row_els
+            else:
+                raise ArchivematicaSeleniumError(
+                    'Unable to find a unique default AIP storage location')
         cell_el = row_els[0].find_elements_by_css_selector('td')[9]
         edit_a_el = None
         for a_el in cell_el.find_elements_by_css_selector('a'):

--- a/features/core/aip-encryption-mirror.feature
+++ b/features/core/aip-encryption-mirror.feature
@@ -1,0 +1,45 @@
+# AIP Encryption via Mirror Locations feature.
+#
+# How to Run this test on a Vagrant/Ansible deploy. (Note that this
+# configuration assumes that the server user is archivematica and has the
+# password 'vagrant'. This means you have to run `su; passwd archivematica`
+# from the VM and set the password to 'vagrant'.)::
+#
+#     $ behave --tags=aip-encrypt-mirror \
+#       --no-skipped \
+#       -D am_version=1.7 \
+#       -D driver_name=Firefox \
+#       -D server_user=archivematica
+
+@aip-encrypt-mirror @am17
+Feature: AIP Encryption via Mirror Locations
+  Archivematica users want to be able to store AIPs unencrypted with encrypted
+  replicas in mirror locations. This allows easy access to unencrypted AIPs
+  as well as the ability to make redundant copies of encrypted replicas
+  off-site.
+
+  @compressed
+  Scenario: Richard wants to create an AIP with an encrypted replica.
+    Given there is a standard GPG-encrypted space in the storage service
+    And there is a standard GPG-encrypted Replicator location in the storage service
+    And the default AIP Storage location has the GPG-encrypted Replicator location as its replicator
+    And the default processing config is in its default state
+    When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer
+    And standard AIP-creation decisions are made
+    And the user waits for the "Store AIP location" decision point to appear and chooses "Store AIP in standard Archivematica Directory" during ingest
+    And the user waits for the AIP to appear in archival storage
+    And the user searches for the AIP UUID in the Storage Service
+    Then the master AIP and its replica are returned by the search
+    When the user downloads the master AIP pointer file
+    And the user downloads the replica AIP pointer file
+    Then the master AIP pointer file contains a(n) replication PREMIS:EVENT
+    And the replica AIP pointer file contains a(n) creation PREMIS:EVENT
+    And the replica AIP pointer file contains a(n) validation PREMIS:EVENT
+    And the master AIP pointer file contains a PREMIS:OBJECT with a derivation relationship pointing to the replica AIP and the replication PREMIS:EVENT
+    And the replica AIP pointer file contains a PREMIS:OBJECT with a derivation relationship pointing to the master AIP and the replication PREMIS:EVENT
+    And the replica AIP pointer file contains a mets:transformFile element for the encryption event
+    And the replica AIP pointer file contains a(n) encryption PREMIS:EVENT
+    And the master AIP on disk is not encrypted
+    And the replica AIP on disk is encrypted
+    When the user downloads the replica AIP
+    Then the downloaded replica AIP is not encrypted


### PR DESCRIPTION
Added a feature file that tests that AIPs can be replicated into encrypted spaces, thus allowing for the creation of an AIP and an encrypted replica of that AIP. This should pass on an Archivematica install running [AM branch dev/issue-10662-mirror-locations](https://github.com/artefactual/archivematica/pull/738) and SS branch dev/issue-10662-mirror-locations.

To run this new feature on a Vagrant/Ansible install of Archivematica, change the archivematica user's password to 'vagrant' (e.g., by running `su` and then `passwd archivematica`) and then run:

    $ behave \
        --tags=aip-encrypt-mirror \
        --no-skipped \
        -D am_version=1.7 \
        -D driver_name=Firefox \
        -D server_user=archivematica

The previous tests for AIP encryption should also still pass. To confirm that the core scenario passes, run:

    $ behave \
        --tags=aip-encrypt \
        --tags=compressed \
        --no-skipped \
        -D am_version=1.7 \
        -D driver_name=Firefox \
        -D server_user=archivematica