### PR TITLE
Add CCA feature files for DIP creation and upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 env/
+.env/
 sandbox/
 am-mc-commands/
 test-transfers-sandbox/

--- a/archivematicaselenium.py
+++ b/archivematicaselenium.py
@@ -288,7 +288,9 @@ class ArchivematicaSelenium:
         - Firefox 47.01 (*note* does not work on v. 48.0)
         """
         self.driver = self.get_driver()
-        if self.driver_name not in ('Chrome-Hub',):
+        # Do not maximize window in Chrome to workaround:
+        # https://bugs.chromium.org/p/chromedriver/issues/detail?id=1901
+        if self.driver_name not in ('Chrome-Hub', 'Chrome'):
             self.driver.maximize_window()
 
     def tear_down(self):
@@ -595,7 +597,7 @@ class ArchivematicaSelenium:
         return None
 
     def get_sip_uuid(self, transfer_name):
-        self.driver.close()
+        self.driver.quit()
         self.driver = self.get_driver()
         ingest_url = self.get_ingest_url()
         self.driver.get(ingest_url)
@@ -1238,7 +1240,7 @@ class ArchivematicaSelenium:
             if link_button.text.strip() == 'Next Page':
                 next_tasks_url = '{}{}'.format(
                     self.am_url, link_button.get_attribute('href'))
-        self.driver.close()
+        self.driver.quit()
         if next_tasks_url:
             table_dict = self._parse_tasks_table_am_1_6(
                 next_tasks_url, table_dict)
@@ -1290,7 +1292,7 @@ class ArchivematicaSelenium:
             if link_button.text.strip() == 'Next page':
                 next_tasks_url = '{}{}'.format(
                     self.am_url, link_button.get_attribute('href'))
-        self.driver.close()
+        self.driver.quit()
         if next_tasks_url:
             table_dict = self._parse_tasks_table_am_1_7(
                 next_tasks_url, table_dict)
@@ -1561,7 +1563,7 @@ class ArchivematicaSelenium:
         normalization report, parse it and return a list of dicts.
         """
         report = []
-        self.driver.close()
+        self.driver.quit()
         self.driver = self.get_driver()
         url = self.get_ingest_url()
         self.driver.get(url)

--- a/features/CCA/create_CCA_dip.feature
+++ b/features/CCA/create_CCA_dip.feature
@@ -1,0 +1,49 @@
+# Create CCA Dissemination Information Package feature file
+#
+# The following feature requires an instance of Archivematica 1.6 and the
+# Storage Service 0.8 with an AIP already ingested.
+#
+# To pass this test, Behave requires some parameters passed as user data:
+#
+#   $ behave \
+#     --tags=create_CCA_dip \
+#     --no-skipped \
+#     -D aip_uuid=<UUID> \
+#     -D transfer_name=<TRANSFER_NAME>
+#     -D output_dir=/path/to/output_dir
+#     -D files_csv=/path/to/files.csv
+#
+# Example of files_csv file:
+#
+#   filename,lastmodified
+#   "./image.png",1510647651
+#   "./folder1/file 1.txt",1510647659
+#   "./folder2/file 2.txt",
+#
+# Use a relative path to the objects folder for the filename and an Unix
+# epoch time for the lastmodified date. If a last modified date should not
+# be checked, because the date is missing in the FITS section of the METS
+# file or for other reasons, leave that one empty. One way of getting this
+# information is by navigating to the transfer objects folder and executing:
+#
+#   find -type f -print0 | xargs -0 stat --format '"%n",%Y'
+
+@am16 @create_CCA_dip @automation-tools
+Feature: Create CCA Dissemination Information Package
+  The Canadian Centre for Architecture provides archived architectural drawings and other
+  complex born-digital objects to its researchers.
+  The CCA would like to provide these in Dissemination Information Packages (DIPs) that
+  are easy for researchers to load into appropriate software and include any and all
+  dependent digital objects.
+
+  Scenario: Creating DIP with automation tools
+    Given Tim has configured the automation-tools DIP creation bash script with all the required parameters
+    And he has created that AIP using the current version of Archivematica (1.6.x)
+    When he executes the DIP creation script
+    Then the script retrieves the AIP and creates a new DIP named with the original Transfer name appended with the AIP UUID and “_DIP”
+    And the DIP METS XML file that describes the contents of the DIP
+    And the DIP objects directory contains one zip container with all objects from the original transfer
+    And each DIP object file has its original filename and last modified date from the original transfer
+    And the DIP zip file includes a copy of the submissionDocumentation from the original Transfer
+      And a copy of the AIP METS file generated during ingest
+    And the DIP is stored locally in the output directory specified in the script parameters

--- a/features/CCA/upload_CCA_dip.feature
+++ b/features/CCA/upload_CCA_dip.feature
@@ -1,0 +1,21 @@
+# Upload CCA Dissemination Information Package feature file
+#
+# The following feature has been created to determine how the automation-tools
+# dips.atom_upload.py (called through etc/atom_upload_script.sh) should work.
+#
+# The scenario included in this feature has not been automated yet.
+
+@am16 @upload_CCA_dip @automation-tools @non-executable
+Feature: Upload CCA Dissemination Information Package
+  The create_CCA_dip feature creates a CCA specific Dissemination Information Package.
+  This feature allows that DIP to be uploaded from the local file system to an
+  ATOM repository.
+
+ Scenario: Upload DIP with automation tools
+   Given Tim has created a DIP using the create_CCA_Dip script
+   And configured the automation-tools DIP upload script with all the required parameters
+   And that the local machine can connect to the ATOM repository using rsync
+   When Tim initiates the DIP upload script providing the DIP location and ATOM parameters
+   Then the DIP Upload Script retrieves the DIP from the local filesystem
+   And the DIP is uploaded to the instance of ATOM indicated in the parameters
+   And the DIP can be accessed in ATOM

--- a/features/environment.py
+++ b/features/environment.py
@@ -19,7 +19,7 @@ SS_API_KEY = None
 TRANSFER_SOURCE_PATH = 'vagrant/archivematica-sampledata/TestTransfers/acceptance-tests'
 HOME = 'vagrant'
 DRIVER_NAME = 'Chrome'
-
+AUTOMATION_TOOLS_PATH = '/etc/archivematica/automation-tools'
 # Set these constants if the AM client should be able to gain SSH access to the
 # server where AM is being served. This is needed in order to scp server files
 # to local, which some tests need. If SSH access is not possible, set
@@ -67,6 +67,8 @@ def before_scenario(context, scenario):
     context.TRANSFER_SOURCE_PATH = userdata.get(
         'transfer_source_path', TRANSFER_SOURCE_PATH)
     context.HOME = userdata.get('home', HOME)
+    context.AUTOMATION_TOOLS_PATH = userdata.get(
+        'automation_tools_path', AUTOMATION_TOOLS_PATH)
 
 
 def after_scenario(context, scenario):

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1,3 +1,4 @@
+import csv
 import filecmp
 import json
 import logging
@@ -5,8 +6,10 @@ from lxml import etree
 import os
 import pprint
 import re
+import subprocess
 import tarfile
 import time
+import zipfile
 
 from behave import when, then, given, use_step_matcher
 
@@ -1542,6 +1545,131 @@ use_step_matcher('parse')
 @then('the downloaded uncompressed AIP is an unencrypted tarfile')
 def step_impl(context):
     assert tarfile.is_tarfile(context.scenario.aip_path)
+
+
+###############################################################################
+# FEATURE: CREATE CCA DIP
+###############################################################################
+
+
+@given('Tim has configured the automation-tools DIP creation bash script with all the required parameters')
+def step_impl(context):
+    # Check if the DIP creation script exists and is executable
+    context.script = os.path.join(context.AUTOMATION_TOOLS_PATH,
+                                  'create_dip_script.sh')
+    assert os.path.isfile(context.script)
+    assert os.access(context.script, os.X_OK)
+
+    # Get AIP UUID, transer name and output dir from user data
+    userdata = context.config.userdata
+    context.aip_uuid =  userdata.get('aip_uuid')
+    context.transfer_name = userdata.get('transfer_name')
+    context.output_dir = userdata.get('output_dir')
+    assert context.aip_uuid
+    assert context.transfer_name
+    assert context.output_dir
+
+
+@given('he has created that AIP using the current version of Archivematica (1.6.x)')
+def step_impl(context):
+    # Not the best way to check the AIP existence
+    # as the request won't fail if AM is in debug mode.
+    # Should we check directly in the SS API?
+    context.am_sel_cli.navigate_to_aip_in_archival_storage(context.aip_uuid)
+
+
+@when('he executes the DIP creation script')
+def step_impl(context):
+    output = subprocess.check_output([context.script], stderr=subprocess.STDOUT)
+    logger.info('Create DIP script output:\n%s', output.decode())
+
+
+@then('the script retrieves the AIP and creates a new DIP named with the original Transfer name appended with the AIP UUID and “_DIP”')
+def step_impl(context):
+    dip_name = '{}_{}_DIP'.format(context.transfer_name, context.aip_uuid)
+    context.dip_path = os.path.join(context.output_dir, dip_name)
+    assert os.path.exists(context.dip_path)
+
+
+@then('the DIP METS XML file that describes the contents of the DIP')
+def step_impl(context):
+    mets_filename = 'METS.{}.xml'.format(context.aip_uuid)
+    context.mets_path = os.path.join(context.dip_path, mets_filename)
+    assert os.path.exists(context.mets_path)
+
+
+@then('the DIP objects directory contains one zip container with all objects from the original transfer')
+def step_impl(context):
+    objects_path = os.path.join(context.dip_path, 'objects')
+    context.zip_path = os.path.join(objects_path,
+                                    '{}.zip'.format(context.transfer_name))
+    assert os.path.exists(context.zip_path)
+
+
+@then('each DIP object file has its original filename and last modified date from the original transfer')
+def step_impl(context):
+    # Get objects files info from CSV file
+    userdata = context.config.userdata
+    files_csv_path =  userdata.get('files_csv')
+    files = []
+    with open(files_csv_path) as csv_file:
+        reader = csv.DictReader(csv_file)
+        for row in reader:
+            filename = row['filename']
+            if filename.startswith('./'):
+                filename = filename[2:]
+            files.append({
+                'filename': filename,
+                'lastmodified': row['lastmodified']
+            })
+    assert files
+    # Check file info in ZIP files
+    with zipfile.ZipFile(context.zip_path, 'r') as zip_file:
+        for file_info in zip_file.infolist():
+            # Strip transfer name and '/', the main folder will end empty
+            filename = file_info.filename[len(context.transfer_name) + 1:]
+            # Ignore main folder, METS, submissionDocumentation and directories
+            if (not filename or
+                filename == 'METS.{}.xml'.format(context.aip_uuid) or
+                filename.startswith('submissionDocumentation') or
+                filename.endswith('/')):
+                continue
+            lastmodified = int(time.mktime(file_info.date_time + (0, 0, -1)))
+            # Find file by filename in file info from CSV
+            csv_info = next((x for x in files if x['filename'] == filename), None)
+            assert csv_info
+            # Check lastmodified date, if present in CSV
+            csv_lastmodified = csv_info['lastmodified']
+            if not csv_info['lastmodified']:
+                continue
+            csv_lastmodified = int(csv_info['lastmodified'])
+            # Somehow, between getting the last modified date from the METS file,
+            # setting it in the DIP files with os.utime(), zipping the files and
+            # getting it in here with infolist(), a mismatch of a second is found
+            # in some of the files. No milliseconds are involved in the process so
+            # this should not be a rounding issue.
+            assert csv_lastmodified - 1 <= lastmodified <= csv_lastmodified + 1
+
+
+@then('the DIP zip file includes a copy of the submissionDocumentation from the original Transfer')
+def step_impl(context):
+    sub_folder = '{}/submissionDocumentation/'.format(context.transfer_name)
+    with zipfile.ZipFile(context.zip_path, 'r') as zip_file:
+        assert sub_folder in zip_file.namelist()
+
+
+@then('a copy of the AIP METS file generated during ingest')
+def step_impl(context):
+    mets_filename = '{}/METS.{}.xml'.format(context.transfer_name,
+                                            context.aip_uuid)
+    with zipfile.ZipFile(context.zip_path, 'r') as zip_file:
+        assert mets_filename in zip_file.namelist()
+
+
+@then('the DIP is stored locally in the output directory specified in the script parameters')
+def step_impl(context):
+    # Already checked in previous steps
+    pass
 
 
 ###############################################################################


### PR DESCRIPTION
Includes two feature files to describe the requirements of two new scripts
in the automation-tools project, one to create a DIP from an AIP in the SS
and the other to upload a DIP folder to an AtoM instance. Only the
create_CCA_dip.feature file is fully automated.

See https://github.com/artefactual-labs/archivematica-acceptance-tests/issues/29