### PR TITLE
Fix metadata-only AIP re-ingest feature

### DIFF
--- a/features/core/metadata-only-aip-reingest.feature
+++ b/features/core/metadata-only-aip-reingest.feature
@@ -9,27 +9,35 @@ Feature: Metadata-only AIP re-ingest
     Given that the user has ensured that the default processing config is in its default state
     And the reminder to add metadata is enabled
     When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer
+    And the user waits for the "Assign UUIDs to directories?" decision point to appear and chooses "No" during transfer
     And the user waits for the "Select file format identification command" decision point to appear and chooses "Identify using Fido" during transfer
+    And the user waits for the "Perform policy checks on originals?" decision point to appear and chooses "No" during transfer
     And the user waits for the "Create SIP(s)" decision point to appear and chooses "Create single SIP and continue processing" during transfer
     And the user waits for the "Normalize" decision point to appear and chooses "Normalize for preservation" during ingest
     And the user waits for the "Approve normalization (review)" decision point to appear and chooses "Approve" during ingest
+    And the user waits for the "Perform policy checks on preservation derivatives?" decision point to appear and chooses "No" during ingest
+    And the user waits for the "Perform policy checks on access derivatives?" decision point to appear and chooses "No" during ingest
     And the user waits for the "Reminder: add metadata if desired" decision point to appear and chooses "Continue" during ingest
     And the user waits for the "Select file format identification command|Process submission documentation" decision point to appear and chooses "Identify using Fido" during ingest
+    And the user waits for the "Bind PIDs?" decision point to appear and chooses "No" during ingest
     And the user waits for the "Store AIP (review)" decision point to appear during ingest
     Then in the METS file the metsHdr element has a CREATEDATE attribute but no LASTMODDATE attribute
-    And in the METS file the metsHdr element has no dmdSec element as a next sibling
+    And in the METS file the metsHdr element has two dmdSec next sibling element(s)
     When the user chooses "Store AIP" at decision point "Store AIP (review)" during ingest
     And the user waits for the "Store AIP location" decision point to appear and chooses "Store AIP in standard Archivematica Directory" during ingest
     And the user waits for the AIP to appear in archival storage
     And the user initiates a metadata-only re-ingest on the AIP
     And the user waits for the "Approve AIP reingest" decision point to appear and chooses "Approve AIP reingest" during ingest
     And the user waits for the "Normalize" decision point to appear and chooses "Do not normalize" during ingest
+    And the user waits for the "Perform policy checks on preservation derivatives?" decision point to appear and chooses "No" during ingest
+    And the user waits for the "Perform policy checks on access derivatives?" decision point to appear and chooses "No" during ingest
     And the user waits for the "Reminder: add metadata if desired" decision point to appear during ingest
     And the user adds metadata
     And the user chooses "Continue" at decision point "Reminder: add metadata if desired" during ingest
     And the user waits for the "Select file format identification command|Process submission documentation" decision point to appear and chooses "Identify using Fido" during ingest
+    And the user waits for the "Bind PIDs?" decision point to appear and chooses "No" during ingest
     And the user waits for the "Store AIP (review)" decision point to appear during ingest
     Then in the METS file the metsHdr element has a CREATEDATE attribute and a LASTMODDATE attribute
-    And in the METS file the metsHdr element has one dmdSec element as a next sibling
+    And in the METS file the metsHdr element has three dmdSec next sibling element(s)
     And in the METS file the dmdSec element contains the metadata added
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -823,19 +823,31 @@ def step_impl(context, conj_quant):
     # del context.scenario.mets
 
 
-@then('in the METS file the metsHdr element has {quant} dmdSec element as a next'
-      ' sibling')
+@then('in the METS file the metsHdr element has {quant} dmdSec next sibling'
+      ' element(s)')
 def step_impl(context, quant):
     mets = get_mets_from_scenario(context)
     mets_dmd_sec_els = mets.findall('.//mets:dmdSec', context.am_sel_cli.mets_nsmap)
-    if quant == 'no':
-        assert len(mets_dmd_sec_els) == 0
-    elif quant == 'one':
-        assert len(mets_dmd_sec_els) == 1
-    else:
+    try:
+        quant = {
+            'no': 0,
+            'zero': 0,
+            'one': 1,
+            'two': 2,
+            'three': 3,
+            'four': 4,
+            'five': 5,
+            'six': 6,
+            'seven': 7,
+            'eight': 8,
+            'nine': 9,
+        }[quant]
+    except KeyError:
         raise ArchivematicaSeleniumStepsError('Unable to recognize the'
             ' quantifier {} when checking for dmdSec elements in the METS'
             ' file'.format(quant))
+    else:
+        assert len(mets_dmd_sec_els) == quant
 
 
 @then('in the METS file the dmdSec element contains the metadata added')


### PR DESCRIPTION
Changes in qa/1.x (towards AM v. 1.7) caused the feature file in
features/core/metadata-only-aip-reingest.feature to fail. This commit
makes that feature file pass again against AM qa/1.x, specifically at
99922b55bf3c741d409957cb04f520cf989868a6.

Fixes https://github.com/artefactual-labs/archivematica-acceptance-tests/issues/41