### PR TITLE
Add feature: performance gains without stdout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 env/
+data/
 .env/
 sandbox/
 am-mc-commands/

--- a/amuser/am_browser_file_explorer_ability.py
+++ b/amuser/am_browser_file_explorer_ability.py
@@ -76,6 +76,7 @@ class ArchivematicaBrowserFileExplorerAbility(
         path = path.strip('/')
         path_parts = path.split('/')
         for i, folder in enumerate(path_parts):
+            LOGGER.info('Clicking on "%s"', folder)
             is_last = False
             if i == len(path_parts) - 1:
                 is_last = True
@@ -87,7 +88,7 @@ class ArchivematicaBrowserFileExplorerAbility(
             # should be, i.e., this is now an absolute XPath.
             folder_label_xpath = c.XPATH_TREEITEM_NEXT_SIBLING.join(xtrail)
             # Wait until folder is visible.
-            block = WebDriverWait(self.driver, 1)
+            block = WebDriverWait(self.driver, 3)
             block.until(EC.presence_of_element_located(
                 (By.XPATH, folder_label_xpath)))
             if is_last:

--- a/amuser/am_browser_ingest_ability.py
+++ b/amuser/am_browser_ingest_ability.py
@@ -41,6 +41,7 @@ class ArchivematicaBrowserIngestAbility(
             self.remove_top_transfer(top_transfer_elem)
 
     def get_sip_uuid(self, transfer_name):
+        LOGGER.info('Getting SIP UUID from transfer name %s', transfer_name)
         self.driver.quit()
         self.driver = self.get_driver()
         ingest_url = self.get_ingest_url()
@@ -50,10 +51,13 @@ class ArchivematicaBrowserIngestAbility(
         self.driver.get(ingest_url)
         sip_uuid, _, _ = (
             self.wait_for_transfer_to_appear(transfer_name))
+        LOGGER.info('Got SIP UUID %s', sip_uuid)
         return sip_uuid
 
     def get_mets(self, transfer_name, sip_uuid=None, parse_xml=True):
-        """Return the METS file XML as a string.
+        """Return the METS file XML as an lxml instance or as a string if
+        ``parse_xml`` is set to ``False``.
+
         WARNING: this only works if the processingMCP.xml config file is set to
         *not* store the AIP.
         """

--- a/amuser/am_docker_ability.py
+++ b/amuser/am_docker_ability.py
@@ -1,0 +1,69 @@
+"""Archivematica Docker Ability
+
+This module contains the ``ArchivematicaDockerAbility`` class, which encodes the
+ability of an Archivematica user to use Docker to interact configure and deploy
+Archivematica.
+"""
+
+import os
+import shlex
+import subprocess
+
+from . import utils
+from . import base
+
+
+LOGGER = utils.LOGGER
+
+
+class ArchivematicaDockerAbility(base.Base):
+    """Archivematica Docker Ability: the ability of an Archivematica user to use
+    Docker configure and deploy Archivematica.
+    """
+
+    @property
+    def docker_compose_file_path(self):
+        return os.path.join(self.docker_compose_path, 'docker-compose.yml')
+
+    def recreate_archivematica(self, capture_output=False):
+        """Recreate the docker-compose deploy of Archivematica by calling
+        docker-compose's ``up`` subcommand.
+        """
+        dc_recreate_cmd = 'docker-compose -f {} up -d'.format(
+            self.docker_compose_file_path)
+        capture_output = {True: 'true'}.get(capture_output, 'false')
+        env = dict(os.environ,
+                   AM_CAPTURE_CLIENT_SCRIPT_OUTPUT=capture_output)
+        subprocess.check_output(shlex.split(dc_recreate_cmd), env=env)
+
+    def get_tasks_from_sip_uuid(self, sip_uuid, mysql_user='root',
+                                mysql_password='12345'):
+        """Use ``docker-compose exec mysql`` to get all tasks used to create a
+        given SIP as a list of dicts.
+        """
+        tasks = []
+        sql_query = (
+            'SELECT t.fileUUID as file_uuid,'
+            ' f.fileSize as file_size,'
+            ' LENGTH(t.stdOut) as len_std_out,'
+            ' LENGTH(t.stdError) as len_std_err,'
+            ' t.exec,'
+            ' t.endTime,'
+            ' t.startTime,'
+            ' TIMEDIFF(t.endTime,t.startTime) as duration'
+            ' FROM Tasks t'
+            ' INNER JOIN Files f ON f.fileUUID=t.fileUUID'
+            ' WHERE f.sipUUID=\'{}\''
+            ' ORDER by endTime-startTime, exec;'.format(sip_uuid))
+        cmd_str = (
+            'docker-compose exec mysql mysql -u {} -p{} MCP -e "{}"'.format(
+                mysql_user, mysql_password, sql_query))
+        res = subprocess.check_output(
+            shlex.split(cmd_str),
+            cwd=self.docker_compose_path).decode('utf8')
+        lines = [l for l in res.splitlines() if l.startswith('|')]
+        keys = [k.strip() for k in lines[0].strip(' |').split('|')]
+        for line in lines[1:]:
+            vals = [v.strip() for v in line.strip(' |').split('|')]
+            tasks.append(dict(zip(keys, vals)))
+        return tasks

--- a/amuser/amuser.py
+++ b/amuser/amuser.py
@@ -10,6 +10,7 @@ import subprocess
 
 from . import am_api_ability
 from . import am_browser_ability
+from . import am_docker_ability
 from . import am_ssh_ability
 from . import am_mets_ability
 from . import base
@@ -35,6 +36,8 @@ class ArchivematicaUser(base.Base):
         super().__init__(**kwargs)
         self.browser = am_browser_ability.ArchivematicaBrowserAbility(**kwargs)
         self.ssh = am_ssh_ability.ArchivematicaSSHAbility(
+            **kwargs)
+        self.docker = am_docker_ability.ArchivematicaDockerAbility(
             **kwargs)
         self.api = am_api_ability.ArchivematicaAPIAbility(**kwargs)
         self.mets = am_mets_ability.ArchivematicaMETSAbility(**kwargs)

--- a/amuser/base.py
+++ b/amuser/base.py
@@ -12,6 +12,10 @@ class ArchivematicaUserError(Exception):
     pass
 
 
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
 class Base:
     """Base class for Archivematica user- and ability-type classes. Should only
     hold common functionality for configuring state.
@@ -65,16 +69,24 @@ class Base:
         self._ss_api_key = None
         self.cwd = None
         self._tmp_path = None
+        self._permanent_path = None
 
     @staticmethod
     def unique_name(name):
         return '{}_{}'.format(name, utils.unixtimestamp())
 
     @property
+    def permanent_path(self):
+        if not self._permanent_path:
+            self._permanent_path = os.path.join(ROOT, c.PERM_DIR_NAME)
+            if not os.path.isdir(self._permanent_path):
+                os.makedirs(self._permanent_path)
+        return self._permanent_path
+
+    @property
     def tmp_path(self):
         if not self._tmp_path:
-            here = os.path.dirname(os.path.abspath(__file__))
-            self._tmp_path = os.path.join(here, c.TMP_DIR_NAME)
+            self._tmp_path = os.path.join(ROOT, c.TMP_DIR_NAME)
             if not os.path.isdir(self._tmp_path):
                 os.makedirs(self._tmp_path)
         return self._tmp_path

--- a/amuser/constants.py
+++ b/amuser/constants.py
@@ -18,6 +18,7 @@ JOB_OUTPUTS_COMPLETE = (
     'Completed successfully',
     'Awaiting decision')
 TMP_DIR_NAME = '.amsc-tmp'
+PERM_DIR_NAME = 'data'
 # General timeout for page load and JS changes (in seconds)
 GENERAL_TIMEOUT = 5
 
@@ -325,7 +326,7 @@ PC_DECISION2ID = {
 # Wait/attempt count constants
 # =========================================================================
 
-WAIT_FOR_TRANSFER_TO_APPEAR_MAX_WAITS = 200
+WAIT_FOR_TRANSFER_TO_APPEAR_MAX_WAITS = 1000
 MAX_CLICK_TRANSFER_DIRECTORY_TRIES = 5
 MAX_CLICK_AIP_DIRECTORY_TRIES = 5
 

--- a/features/core/performance-stdout-no-write.feature
+++ b/features/core/performance-stdout-no-write.feature
@@ -1,0 +1,137 @@
+# Performance Increase Without Output Streams Feature File
+# ==============================================================================
+#
+# Warning: this feature file should only be run in development. It requires a
+# docker-compose-based Archivematica deploy. The test itself must be able to
+# alter the deployment by changing an environment variable and recreating a
+# docker container. This feature was developed against an AM deploy created
+# using https://github.com/artefactual-labs/am on branch
+# dev/issue-11443-performance-no-capture-output.
+#
+# To run the test, deploy Archivematica locally using
+# https://github.com/artefactual-labs/am::
+#
+#     $ git clone https://github.com/artefactual-labs/am
+#     $ git checkout dev/issue-11443-performance-no-capture-output
+#     $ cd am/compose
+#     $ git submodule update --init --recursive
+#     $ make create-volumes
+#     $ docker-compose up -d --build
+#     $ make bootstrap
+#     $ make restart-am-services
+#
+# Then run the following `behave` command, after replacing the
+# `docker_compose_path` userdata option with the appropriate value for your
+# development system::
+#
+#     behave \
+#         --tags=performance-no-stdout \
+#         --no-skipped \
+#         --no-capture \
+#         -D driver_name=Firefox \
+#         -D am_url=http://127.0.0.1:62080/ \
+#         -D am_password=test \
+#         -D home="" \
+#         -D am_version=1.7 \
+#         -D docker_compose_path=/abs/path/to/am/compose
+#         -D home=archivematica
+#
+#     behave --tags=performance-no-stdout --no-skipped --no-capture -D driver_name=Firefox -D am_url=http://127.0.0.1:62080/ -D am_password=test -D home="" -D am_version=1.7 -D docker_compose_path=/Users/joeldunham/Documents/Artefactual/am/compose -D home=archivematica
+
+# Results
+# ==============================================================================
+#
+# Results against archivematica-sampledata/SampleTransfers/Images (11 MB)
+# ------------------------------------------------------------------------------
+#
+# 1. Total runtime for without output tasks: 412.99 seconds
+#    Total runtime for with output tasks:    439.22 seconds
+#
+# 2. Total runtime for without output tasks: 394.35 seconds
+#    Total runtime for with output tasks:    434.23 seconds
+#
+# 3. Total runtime for without output tasks: 429.57 seconds
+#    Total runtime for with output tasks:    444.76 seconds
+#
+# 4. Total runtime for without output tasks: 111.50 seconds
+#    Total runtime for with output tasks:    117.95 seconds
+#
+# 5. Total runtime for without output tasks: 432.25 seconds
+#    Total runtime for with output tasks:    472.20 seconds
+#
+# Note: run (4) was on a linux host, where docker containers run faster.
+#
+#
+# Analysis
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#
+# Average runtime for without output tasks:  337.10 seconds
+# Average runtime for with output tasks:     359.04 seconds
+# Average time reduction:                      6.11 %
+
+
+# Results against CUL-Transfer-1 (1.8 GB)
+# ------------------------------------------------------------------------------
+#
+# This transfer contains 9 129 MB .tif files and 9 70 MB .tif files.
+#
+# 1. Total runtime for without output tasks: 514.10 seconds
+#    Total runtime for with output tasks:    553.88 seconds
+#
+#
+# Analysis
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#
+# Average runtime for without output tasks: 514.10 seconds
+# Average runtime for with output tasks:    535.88 seconds
+# Average time reduction:                     7.18 %
+
+
+@performance-no-stdout @developer
+Feature: Performance increase: stop saving stdout/stderr
+  Archivematica's developers want to test whether preventing client scripts
+  from sending their stdout and stderr to MCPServer to be saved to the database
+  will result in a significant performance increase.
+
+  Scenario Outline: Joel creates an AIP on an Archivematica instance that saves stdout/err and on one that does not. He expects that the processing time of the AIP on the first instance will be less than that of the AIP on the second one.
+    Given an Archivematica instance that passes client script output streams to MCPServer
+    And the default processing config is set to automate a transfer through to "Store AIP"
+
+    When a transfer is initiated on directory <transfer_source>
+    And the user waits for the "Store AIP (review)" decision point to appear during ingest
+    And performance statistics are saved to with_outputs_stats
+
+    Then performance statistics show output streams are saved to the database
+
+    When the user alters the Archivematica instance to not pass client script output streams to MCPServer
+    And a transfer is initiated on directory <transfer_source>
+    And the user waits for the "Store AIP (review)" decision point to appear during ingest
+    And performance statistics are saved to without_outputs_stats
+
+    Then performance statistics show output streams are not saved to the database
+    And the runtime of client scripts in without_outputs_stats is less than the runtime of client scripts in with_outputs_stats
+    # Note: this will currently fail because ceasing to pass client script
+    # output streams to MCPServer has no effect on what is written to the METS
+    # file.
+    And the size of the without_outputs_stats METS file is less than that of the with_outputs_stats METS file
+
+    Examples: Archivematica transfer sources
+    | transfer_source                                                        |
+    #| ~/archivematica-sampledata/TestTransfers/small                        |
+    | ~/archivematica-sampledata/SampleTransfers/Images                     |
+    #| ~/TestTransfers/acceptance-tests/performance/images-17M-each-2G-total |
+    #| ~/TestTransfers/acceptance-tests/performance/video-14M-each-10G-total |
+
+    # Listed below are possible metrics of performance increase. Those checked
+    # off are relatively easy to measure and are described in the scenario
+    # above. Those not checked off need further work in order to determine how
+    # they can be measured in this scenario or others.
+    #
+    # - [√] decrease in total processing time (debatable)
+    # - [√] decrease in size of the AIP METS file and AIP Pointer file
+    # - [√] decrease in database usage (significant decrease in total bytes written to db)
+    # - [√] decrease in total size of database
+    # - [ ] increase in number of files processed simultaneously (questionable)
+    # - [ ] increase in size of the largest file that can be processed (questionable)
+    # - [ ] increase in the total number of files that can be included in a single aip
+    # - [ ] decrease in amount of memory required to process the same content

--- a/features/environment.py
+++ b/features/environment.py
@@ -17,7 +17,7 @@ SS_URL = "http://192.168.168.192:8000/"
 SS_API_KEY = None
 # Path relative to /home where transfer sources live.
 TRANSFER_SOURCE_PATH = 'vagrant/archivematica-sampledata/TestTransfers/acceptance-tests'
-HOME = 'vagrant'
+HOME = ''
 DRIVER_NAME = 'Chrome'
 AUTOMATION_TOOLS_PATH = '/etc/archivematica/automation-tools'
 # Set these constants if the AM client should be able to gain SSH access to the
@@ -36,6 +36,7 @@ def get_am_user(userdata):
         'am_username': userdata.get('am_username', AM_USERNAME),
         'am_password': userdata.get('am_password', AM_PASSWORD),
         'am_url': userdata.get('am_url', AM_URL),
+        'alt_am_url': userdata.get('alt_am_url', AM_URL),
         'am_version': userdata.get('am_version', AM_VERSION),
         'am_api_key': userdata.get('am_api_key', AM_API_KEY),
         'ss_username': userdata.get('ss_username', SS_USERNAME),
@@ -79,4 +80,10 @@ def after_scenario(context, scenario):
         context.am_user.browser.change_normalization_rule_command(
             'Access Generic MOV',
             'Transcoding to mp4 with ffmpeg')
+    if scenario.name == (
+            'Joel creates an AIP on an Archivematica instance that saves'
+            ' stdout/err and on one that does not. He expects that the'
+            ' processing time of the AIP on the first instance will be less'
+            ' than that of the AIP on the second one.'):
+        context.am_user.docker.recreate_archivematica(capture_output=True)
     context.am_user.browser.tear_down()

--- a/features/steps/performance_stdout_no_write_steps.py
+++ b/features/steps/performance_stdout_no_write_steps.py
@@ -1,0 +1,146 @@
+"""Steps for the Performance Testing When Output Streams Not Captured
+Test/Feature.
+"""
+
+import json
+import os
+import time
+
+from behave import when, then, given
+from lxml import etree
+
+from features.steps import utils
+
+# ==============================================================================
+# Step Definitions
+# ==============================================================================
+
+# Givens
+# ------------------------------------------------------------------------------
+
+@given('an Archivematica instance that {capture_output} client script output'
+       ' streams to MCPServer')
+def step_impl(context, capture_output):
+    capture_output = {'passes': True}.get(capture_output, False)
+    context.am_user.docker.recreate_archivematica(capture_output=capture_output)
+
+
+# Whens
+# ------------------------------------------------------------------------------
+
+@when('the user alters the Archivematica instance to {capture_output} client'
+      ' script output streams to MCPServer')
+def step_impl(context, capture_output):
+    del context.scenario.sip_uuid
+    capture_output = {'passes': True}.get(capture_output, False)
+    context.am_user.docker.recreate_archivematica(capture_output=capture_output)
+
+
+@when('performance statistics are saved to {filename}')
+def step_impl(context, filename):
+    """Saves task statistics and the contents of the METS file of a
+    transfer/AIP to a JSON file at ``filename`` suffixed with Unix timestamp in
+    the permanent directory.
+
+    Makes MySQL queries in a docker-compose-dependent way in order to do this.
+    In future iterations, this should use AM's API, when that API is
+    sufficiently developed.
+    """
+    sip_uuid = context.scenario.sip_uuid
+    data = {'mets': etree.tostring(utils.get_mets_from_scenario(context),
+                                   pretty_print=True).decode('utf8'),
+            'tasks': context.am_user.docker.get_tasks_from_sip_uuid(
+                sip_uuid)}
+    filename = '{}-{}.json'.format(filename, int(time.time()))
+    path = os.path.join(context.am_user.permanent_path, filename)
+    with open(path, 'w') as fout:
+        json.dump(data, fout, indent=4)
+    context.scenario.performance_stats_path = path
+    utils.logger.info('Set performance_stats_path to %s', path)
+
+
+# Thens
+# ------------------------------------------------------------------------------
+
+@then('the size of the {without_outputs_fname} METS file is less than that of'
+      ' the {with_outputs_fname} METS file')
+def step_impl(context, without_outputs_fname, with_outputs_fname):
+    without_outputs_stats = get_stats_file_json(
+        without_outputs_fname, context.am_user.permanent_path)
+    with_outputs_stats = get_stats_file_json(
+        with_outputs_fname, context.am_user.permanent_path)
+    without_outputs_mets = without_outputs_stats['mets']
+    with_outputs_mets = with_outputs_stats['mets']
+    without_outputs_mets_len = len(without_outputs_mets)
+    with_outputs_mets_len = len(with_outputs_mets)
+    utils.logger.info(
+        'METS length for without output tasks: %d', without_outputs_mets_len)
+    utils.logger.info(
+        'METS length for with output tasks: %d', with_outputs_mets_len)
+    assert without_outputs_mets_len < with_outputs_mets_len
+
+
+@then('the runtime of client scripts in {without_outputs_fname} is less'
+      ' than the runtime of client scripts in {with_outputs_fname}')
+def step_impl(context, without_outputs_fname, with_outputs_fname):
+    without_outputs_stats = get_stats_file_json(
+        without_outputs_fname, context.am_user.permanent_path)
+    with_outputs_stats = get_stats_file_json(
+        with_outputs_fname, context.am_user.permanent_path)
+    without_outputs_tasks = without_outputs_stats['tasks']
+    with_outputs_tasks = with_outputs_stats['tasks']
+    assert len(without_outputs_tasks) == len(with_outputs_tasks)
+    without_outputs_tasks = add_duration_float(without_outputs_tasks)
+    with_outputs_tasks = add_duration_float(with_outputs_tasks)
+    wo_o_sum_tasks = sum(t['duration_float'] for t in without_outputs_tasks)
+    w_o_sum_tasks = sum(t['duration_float'] for t in with_outputs_tasks)
+    utils.logger.info('Total runtime for without output tasks: %f', wo_o_sum_tasks)
+    utils.logger.info('Total runtime for with output tasks: %f', w_o_sum_tasks)
+    assert wo_o_sum_tasks < w_o_sum_tasks
+
+
+@then('performance statistics show output streams {verb} saved to the database')
+def step_impl(context, verb):
+    path = context.scenario.performance_stats_path
+    with open(path) as fi:
+        stats = json.load(fi)
+    std_out_len_set = set([x['len_std_out'] for x in stats['tasks']])
+    std_err_len_set = set([x['len_std_err'] for x in stats['tasks']])
+    if verb == 'are':
+        assert len(std_out_len_set) > 1
+        assert len(std_err_len_set) > 1
+    else:
+        assert len(std_out_len_set) == 1, print(std_out_len_set)
+        assert len(std_err_len_set) == 1, print(std_err_len_set)
+
+
+@then('there is no stdout or stderr for the client scripts in {filename}')
+def step_impl(context, filename):
+    pass
+
+
+@then('there is non-zero stdout and stderr for the client scripts in'
+      ' {filename}')
+def step_impl(context, filename):
+    pass
+
+
+# Helpers
+# ------------------------------------------------------------------------------
+
+def add_duration_float(tasks):
+    for task in tasks:
+        task['duration_float'] = utils.get_duration_as_float(task['duration'])
+    return tasks
+
+
+def get_newest_file_with_prefix(dirpath, filename_prefix):
+    files = [f for f in os.listdir(dirpath) if f.startswith(filename_prefix)]
+    return os.path.join(dirpath, sorted(files)[-1])
+
+
+def get_stats_file_json(fname, permanent_path):
+    fpath = get_newest_file_with_prefix(permanent_path, fname)
+    utils.logger.info('file path for %s is %s', fname, fpath)
+    with open(fpath) as fi:
+        return json.load(fi)

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -112,6 +112,34 @@ def step_impl(context):
     )
 
 
+@given('the default processing config is set to automate a transfer through to'
+       ' "Store AIP"')
+def step_impl(context):
+    context.execute_steps(
+        'Given the default processing config is in its default state\n'
+        'And the processing config decision "Assign UUIDs to directories" is'
+        ' set to "No"\n'
+        'And the processing config decision "Select file format identification'
+        ' command (Transfer)" is set to "Identify using Siegfried"\n'
+        'And the processing config decision "Perform policy checks on'
+        ' originals" is set to "No"\n'
+        'And the processing config decision "Create SIP(s)" is set to "Create'
+        ' single SIP and continue processing"\n'
+        'And the processing config decision "Normalize" is set to "Normalize'
+        ' for preservation"\n'
+        'And the processing config decision "Approve normalization" is set to'
+        ' "Yes"\n'
+        'And the processing config decision "Perform policy checks on'
+        ' preservation derivatives" is set to "No"\n'
+        'And the processing config decision "Perform policy checks on access'
+        ' derivatives" is set to "No"\n'
+        'And the processing config decision "Select file format identification'
+        ' command (Submission documentation & metadata)" is set to'
+        ' "Identify using Siegfried"\n'
+        'And the processing config decision "Bind PIDs" is set to "No"'
+    )
+
+
 # Whens
 # ------------------------------------------------------------------------------
 
@@ -232,7 +260,7 @@ def step_impl(context):
     """Standard AIP-creation decisions after a transfer is initiated and up
     until (but not including) the "Store AIP location" decision:
 
-    - file identification via Fido
+    - file identification via Siegfried
     - create SIP
     - normalize for preservation
     - store AIP
@@ -241,7 +269,7 @@ def step_impl(context):
         'When the user waits for the "Assign UUIDs to directories?" decision'
         ' point to appear and chooses "No" during transfer\n'
         'And the user waits for the "Select file format identification command"'
-        ' decision point to appear and chooses "Identify using Fido" during'
+        ' decision point to appear and chooses "Identify using Siegfried" during'
         ' transfer\n'
         'And the user waits for the "Perform policy checks on originals?"'
         ' decision point to appear and chooses "No" during transfer\n'
@@ -260,7 +288,7 @@ def step_impl(context):
         ' ingest\n'
         'And the user waits for the "Select file format identification'
         ' command|Process submission documentation" decision point to'
-        ' appear and chooses "Identify using Fido" during ingest\n'
+        ' appear and chooses "Identify using Siegfried" during ingest\n'
         'And the user waits for the "Bind PIDs?" decision point to appear and'
         ' chooses "No" during ingest\n'
         'And the user waits for the "Store AIP (review)" decision point to'

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -1,5 +1,6 @@
 """Utilities for Steps files."""
 
+import datetime
 import logging
 import os
 import re
@@ -236,3 +237,11 @@ def parse_k_v_attributes(attributes):
     """
     return {pair.split(':')[0].strip(): pair.split(':')[1].strip() for
             pair in attributes.split(';') if pair.strip()}
+
+
+def get_duration_as_float(duration_string):
+    dt = datetime.datetime.strptime(duration_string, '%H:%M:%S.%f')
+    delta = datetime.timedelta(
+        hours=dt.hour, minutes=dt.minute, seconds=dt.second,
+        microseconds=dt.microsecond)
+    return delta.total_seconds()


### PR DESCRIPTION
This commit introduces feature file performance-stdout-no-write.feature, which
first creates an AIP using a version of Archivematica where the MCP client
passes its client script output streams (stdout and stderr) to the MCP server
for ultimate storage in the database. The timing duration of each client
script run in the course of building that AIP is queried from the
database and saved to disk. The feature then modifies the Archivematica
instance so that the MCP client no longer passes output streams to the
server, and it creates a new AIP, and saves information on micro-service
execution time to disk. Finally, it asserts that the micro-services took
less time in the second case than in the first.

This feature is essentially the executable documentation of a performance
experiment against Archivematica. The current finding is that removing
output streams results in a 6% reduction in task execution time.

Warning: it is a known bug that executing this feature will stall at the
second instance of the `And standard AIP-creation decisions are made`
step.

Fixes #32.