### PR TITLE
Add assertion to confirm empty dirs are documented and given PIDs

### DIFF
--- a/features/core/aip-encryption.feature
+++ b/features/core/aip-encryption.feature
@@ -1,20 +1,20 @@
-# behave \
-#     --tags=aip-encrypt \
-#     --tags=compressed \
-#     --no-skipped \
-#     -v \
-#     -D am_username=test \
-#     -D am_password=test \
-#     -D am_url=http://127.0.0.1:62080/ \
-#     -D am_version=1.7 \
-#     -D am_api_key=test \
-#     -D ss_username=test \
-#     -D ss_password=test \
-#     -D ss_url=http://127.0.0.1:62081/ \
-#     -D ss_api_key=test \
-#     -D home=archivematica \
-#     -D driver_name=Firefox
-# behave --tags=aip-encrypt --tags=compressed --no-skipped -v -D am_username=test -D am_password=test -D am_url=http://127.0.0.1:62080/ -D am_version=1.7 -D am_api_key=test -D ss_username=test -D ss_password=test -D ss_url=http://127.0.0.1:62081/ -D ss_api_key=test -D home=archivematica -D driver_name=Firefox
+# To run this feature against a standard am.git docker-compose deploy:
+#
+# $ behave \
+#       --tags=aip-encrypt \
+#       --no-skipped \
+#       -v \
+#       -D am_username=test \
+#       -D am_password=test \
+#       -D am_url=http://127.0.0.1:62080/ \
+#       -D am_version=1.7 \
+#       -D am_api_key=test \
+#       -D ss_username=test \
+#       -D ss_password=test \
+#       -D ss_url=http://127.0.0.1:62081/ \
+#       -D ss_api_key=test \
+#       -D home=archivematica \
+#       -D driver_name=Firefox
 
 @aip-encrypt @am17
 Feature: AIP Encryption

--- a/features/core/pid-binding.feature
+++ b/features/core/pid-binding.feature
@@ -1,4 +1,29 @@
-@pid-binding @dev
+# To run this feature against a standard am.git docker-compose deploy::
+#
+#     $ behave \
+#           --tags=pid-binding \
+#           --no-skipped \
+#           -D am_username=test \
+#           -D am_password=test \
+#           -D am_url=http://127.0.0.1:62080/ \
+#           -D am_api_key=test \
+#           -D ss_username=test  \
+#           -D ss_password=test \
+#           -D ss_url=http://127.0.0.1:62081/ \
+#           -D ss_api_key=test \
+#           -D home=archivematica \
+#           -D driver_name=Firefox \
+#           -D am_version=1.7 \
+#           -D pid_web_service_endpoint=<SOME_URL> \
+#           -D pid_web_service_key=<SOME_SECRET> \
+#           -D handle_resolver_url=<SOME_RESOLVER_URL> \
+#           -D base_resolve_url=<SOME_RESOLVE_URL> \
+#           -D pid_xml_namespace=<SOME_NAMESPACE>
+#
+# Note: appropriate values must be supplied for the <>-enclosed placeholders
+# above.
+
+@pid-binding
 Feature: Archivematica's entities can be assigned PIDs with specified resolution properties.
   Users of Archivematica want to be able to generate Persistent IDentifiers
   (PIDs)---in this case Handle System handles---for Files and SIP/DIPs (and
@@ -13,7 +38,6 @@ Feature: Archivematica's entities can be assigned PIDs with specified resolution
   # NOTE: The SOAP/HTTP API that this last feature is implemented against may
   # be highly idiosyncratic.
 
-  @typical
   Scenario Outline: Lucien wants to create an AIP with a METS file that documents the binding of persistent identifiers to all of the AIP's original files and directories, and to the AIP itself.
     Given a fully automated default processing config
     And default processing configured to assign UUIDs to directories
@@ -23,7 +47,8 @@ Feature: Archivematica's entities can be assigned PIDs with specified resolution
     When a transfer is initiated on directory <directory_path> with accession number <accession_no>
     And the user waits for the "Store AIP (review)" decision point to appear during ingest
     Then the AIP METS file documents PIDs, PURLs, and UUIDs for all files, directories and the package itself
+    And the empty directory in <empty_dir_rel_path> is in the normative structMap and has identifiers
 
     Examples: transfer sources
-    | directory_path                                                                                 | accession_no |
-    | ~/archivematica-sampledata/TestTransfers/acceptance-tests/pid-binding/hierarchy-with-empty-dir | 42           |
+    | directory_path                                                                                 | accession_no | empty_dir_rel_path  |
+    | ~/archivematica-sampledata/TestTransfers/acceptance-tests/pid-binding/hierarchy-with-empty-dir | 42           | dir2/dir2a/dir2aiii |

--- a/features/steps/pid_binding_steps.py
+++ b/features/steps/pid_binding_steps.py
@@ -98,5 +98,13 @@ def step_impl(context):
       ' directories and the package itself')
 def step_impl(context):
     accession_no = getattr(context.scenario, 'accession_no', None)
-    mets = utils.get_mets_from_scenario(context)
+    mets = context.scenario.mets = utils.get_mets_from_scenario(context)
     context.am_user.mets.validate_mets_for_pids(mets, accession_no=accession_no)
+
+
+@then('the empty directory in {empty_dir_rel_path} is in the normative'
+      ' structMap and has identifiers')
+def step_impl(context, empty_dir_rel_path):
+    mets = context.scenario.mets
+    context.am_user.mets.assert_empty_dir_documented_identified(
+        mets, empty_dir_rel_path)


### PR DESCRIPTION
Adds this assertion to the PID Binding feature/scenario: `And the empty directory in <empty_dir_rel_path> is in the normative structMap and has identifiers`.

Tests [AM PR 935](https://github.com/artefactual/archivematica/pull/935) which fixes [AM issue 934](https://github.com/artefactual/archivematica/issues/934).