### PR TITLE
Update tests to pass against Archivematica 1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,4 @@ __pycache__
 behave-tutorial/
 reports/
 data/
-archivematicaselenium.log
-steps.log
+*.log

--- a/README.rst
+++ b/README.rst
@@ -171,6 +171,61 @@ runs scenarios tagged with ``@wip``.
 
     $ behave --wip
 
+How to run these tests against a Docker Compose Archivematica 1.7 deploy
+--------------------------------------------------------------------------------
+
+If you have Archivematica version 1.7 running locally using the `Archivematica
+Docker Compose deployment method`_, the following command should run all of the
+features that are expected to pass on AM 1.7. Note that you must replace
+several `<>`-enclosed variables with values appropriate to your development
+setup::
+
+
+    $ behave \
+          --tags=mo-aip-reingest,icc,ipc,tpc,picc,uuids-dirs,premis-events,pid-binding,aip-encrypt-mirror,aip-encrypt \
+          --no-skipped \
+          -v \
+          -D am_version=1.7 \
+          -D am_url=http://127.0.0.1:62080/ \
+          -D am_username=test \
+          -D am_password=test \
+          -D am_api_key=test \
+          -D ss_url=http://127.0.0.1:62081/ \
+          -D ss_username=test \
+          -D ss_password=test \
+          -D ss_api_key=test \
+          -D home=archivematica \
+          -D transfer_source_path=archivematica/archivematica-sampledata/TestTransfers/acceptance-tests \
+          -D driver_name=Firefox \
+          -D docker_compose_path=<ABS_PATH_TO_DIR_CONTAINING_DOCKER_COMPOSE_FILE> \
+          -D pid_web_service_endpoint=<SOME_URL> \
+          -D pid_web_service_key=<SOME_SECRET> \
+          -D handle_resolver_url=<SOME_RESOLVER_URL> \
+          -D base_resolve_url=<SOME_RESOLVE_URL> \
+          -D pid_xml_namespace=<SOME_NAMESPACE>
+
+If you do not have access to a Handle server for running the PID-binding tests,
+then you can remove the `pid-binding` tag and related behave userdata (`-D`)
+flags to run a smaller set of tests::
+
+    $ behave \
+          --tags=mo-aip-reingest,icc,ipc,tpc,picc,uuids-dirs,premis-events,aip-encrypt-mirror,aip-encrypt \
+          --no-skipped \
+          -v \
+          -D am_version=1.7 \
+          -D am_url=http://127.0.0.1:62080/ \
+          -D am_username=test \
+          -D am_password=test \
+          -D am_api_key=test \
+          -D ss_url=http://127.0.0.1:62081/ \
+          -D ss_username=test \
+          -D ss_password=test \
+          -D ss_api_key=test \
+          -D home=archivematica \
+          -D transfer_source_path=archivematica/archivematica-sampledata/TestTransfers/acceptance-tests \
+          -D driver_name=Firefox \
+          -D docker_compose_path=<ABS_PATH_TO_DIR_CONTAINING_DOCKER_COMPOSE_FILE>
+
 
 Configuration
 ================================================================================
@@ -228,7 +283,7 @@ Archivematica version 1.7 instance at 123.456.123.456 using the Firefox driver::
         -D am_version=1.7
 
 
-Contributors Guide
+Guidelines for Contributors
 ================================================================================
 
 This section provides advice on how to contribute to this repository. At
@@ -240,7 +295,7 @@ be made to.
    - General (i.e., reusable) step functions should be defined in steps/steps.py.
    - Feature-specific step functions should be defined in sister modules to
      steps/steps.py that are named after the feature, e.g.,
-     steps/aipencryptsteps.py.
+     steps/aip_encryption_steps.py.
 
 2. Place reusable logic in steps files in steps/utils.py and import it in
    steps files.
@@ -251,18 +306,23 @@ be made to.
    - Tag features/scenarios that are documentation only, i.e., not implemented
      and not intended to be executed as tests, using `@unexecutable`.
 
-4. Store user data and functionality in the ``ArchivematicaUser`` class of
-   amuser.py.
+4. Implement general user abilities as methods of the ``ArchivematicaUser``
+   class of amuser/amuser.py.
 
-5. Define browser-dependent abilities of the AM user as attributes of
-   ``ArchivematicaBrowserClient`` in ambrowserclient.py.
+5. Define browser-dependent (e.g., Selenium-based) abilities of the
+   ``ArchivematicaUser`` as methods of ``ArchivematicaBrowserAbility`` in
+   amuser/am_browser_ability.py.
 
-6. Define API-dependent abilities of the AM user as attributes of
-   ``ArchivematicaAPIClient`` in amapiclient.py. (Potentially move amclient.py
-   from automation-tools to its own repo/library and make it a dependency of
-   the automation tools.)
+6. Define HTTP API-dependent (e.g., Requests-based) abilities of the
+   ``ArchivematicaUser`` as methods of ``ArchivematicaAPIAbility`` in
+   amuser/am_api_ability.py.
 
-7. Use the steps catalog to view the available steps, i.e., those that have
+7. Similarly, abilities related to METS parsing, SSH interaction, and Docker
+   interaction should be defined as methods of the appropriate class in the
+   appropriate module of the amuser/ package. See the constructor of
+   ``ArchivematicaUser``.
+
+8. Use the steps catalog to view the available steps, i.e., those that have
    been defined in steps files in the steps/ directory::
 
     $ behave --steps-catalog
@@ -275,3 +335,4 @@ be made to.
 .. _Requests: http://docs.python-requests.org/en/master/
 .. _TightVNC: http://www.tightvnc.com/vncserver.1.php
 .. _`deploy pub`: https://github.com/artefactual/deploy-pub.git
+.. _`Archivematica Docker Compose deployment method`: https://github.com/artefactual-labs/am/tree/master/compose

--- a/amuser/am_browser_ability.py
+++ b/amuser/am_browser_ability.py
@@ -11,6 +11,7 @@ import time
 import requests
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import (
+    ElementNotInteractableException,
     ElementNotVisibleException,
     NoSuchElementException,
 )
@@ -121,7 +122,7 @@ class ArchivematicaBrowserAbility(
             try:
                 self.driver.find_element_by_id('id_delete-uuid').click()
                 break
-            except ElementNotVisibleException:
+            except (ElementNotVisibleException, ElementNotInteractableException):
                 self.driver.find_element_by_css_selector(
                     delete_tab_selector).click()
                 time.sleep(1)

--- a/amuser/am_browser_file_explorer_ability.py
+++ b/amuser/am_browser_file_explorer_ability.py
@@ -142,7 +142,7 @@ class ArchivematicaBrowserFileExplorerAbility(
         try:
             if counter > 10:
                 return
-            r = folder_el.click()
+            folder_el.click()
             if not self.driver.find_element_by_css_selector(
                     c.SELECTOR_BUTTON_ADD_DIR_TO_TRANSFER).is_enabled():
                 LOGGER.info('The Add button has not become clickable.')

--- a/amuser/am_browser_file_explorer_ability.py
+++ b/amuser/am_browser_file_explorer_ability.py
@@ -92,14 +92,19 @@ class ArchivematicaBrowserFileExplorerAbility(
             block.until(EC.presence_of_element_located(
                 (By.XPATH, folder_label_xpath)))
             if is_last:
+                LOGGER.info('Clicking to select folder "%s"', folder)
                 # Click target (leaf) folder and then "Add" button.
                 folder_el = self.driver.find_element_by_xpath(folder_label_xpath)
                 self.click_folder_label(folder_el)
+                time.sleep(4)
                 self.click_add_button()
                 self.driver.execute_script('window.scrollTo(0, 0);')
+                LOGGER.info('Clicked to select folder "%s"', folder)
             else:
                 # Click ancestor folder's icon to open its contents.
+                LOGGER.info('Clicking to open folder "%s"', folder)
                 self.click_folder(folder_label_xpath)
+                LOGGER.info('Clicked to open folder "%s"', folder)
 
     def click_add_folder(self, folder_id):
         """Click the "Add" link in the old AM file explorer interface, i.e., to
@@ -132,10 +137,19 @@ class ArchivematicaBrowserFileExplorerAbility(
         self.click_folder_old_browser(file_id, True)
 
     def click_folder_label(self, folder_el, offset=0):
+        LOGGER.info('Attempting to click folder element at offset %s.', offset)
+        counter = 0
         try:
-            folder_el.click()
+            if counter > 10:
+                return
+            r = folder_el.click()
+            if not self.driver.find_element_by_css_selector(
+                    c.SELECTOR_BUTTON_ADD_DIR_TO_TRANSFER).is_enabled():
+                LOGGER.info('The Add button has not become clickable.')
+                raise WebDriverException('ADD is not clickable')
+            LOGGER.info('The Add button has become clickable.')
         except WebDriverException:
-            print('folder element is NOT clickable')
+            counter += 1
             container_el = self.driver.find_element_by_css_selector(
                 '.transfer-tree-container')
             self.driver.execute_script(

--- a/amuser/am_browser_jobs_tasks_ability.py
+++ b/amuser/am_browser_jobs_tasks_ability.py
@@ -38,6 +38,7 @@ class ArchivematicaBrowserJobsTasksAbility(
         representing the execution of the micro-service named ``ms_name`` on
         the transfer/SIP with UUID ``transfer_uuid``.
         """
+        LOGGER.info('exposing job %s', ms_name)
         # Navigate to the Transfers or Ingest tab, depending on ``unit_type``
         # (if we're not there already)
         unit_url = self.get_transfer_url()
@@ -45,6 +46,7 @@ class ArchivematicaBrowserJobsTasksAbility(
             unit_url = self.get_ingest_url()
         self.navigate(unit_url)
         ms_name, group_name = utils.micro_service2group(ms_name)
+        LOGGER.info('expecting job %s to be in group %s', ms_name, group_name)
         # If not visible, click the micro-service group to expand it.
         self.wait_for_transfer_micro_service_group(group_name, transfer_uuid)
         is_visible = self.get_transfer_micro_service_group_elem(
@@ -56,6 +58,7 @@ class ArchivematicaBrowserJobsTasksAbility(
                 group_name, transfer_uuid).click()
         self.wait_for_microservice_visibility(
             ms_name, group_name, transfer_uuid)
+        LOGGER.info('exposed job %s (%s)', ms_name, group_name)
         return ms_name, group_name
 
     def parse_job(self, ms_name, transfer_uuid, unit_type='transfer'):

--- a/amuser/am_browser_preservation_planning_ability.py
+++ b/amuser/am_browser_preservation_planning_ability.py
@@ -44,7 +44,7 @@ class ArchivematicaBrowserPreservationPlanningAbility(
     def set_fpr_command(self, command_name):
         command_select_el = self.driver.find_element_by_id('id_f-command')
         command_select_el.click()
-        command_select_el.send_keys(command_name)
+        Select(command_select_el).select_by_visible_text(command_name)
         command_select_el.send_keys(Keys.RETURN)
 
     def save_fpr_command(self):

--- a/amuser/constants.py
+++ b/amuser/constants.py
@@ -128,6 +128,7 @@ MICRO_SERVICES2GROUPS = {
     'Designate to process as a standard transfer': ('Quarantine',),
     'Determine if transfer contains packages': ('Extract packages',),
     'Determine which files to identify': ('Identify file format',),
+    'Document empty directories?': ('Generate AIP METS',),
     'Examine contents?': ('Examine contents',),
     'Find type to process as': ('Quarantine',),
     'Generate METS.xml document': ('Generate METS.xml document', 'Generate AIP METS'),

--- a/features/core/aip-encryption-mirror.feature
+++ b/features/core/aip-encryption-mirror.feature
@@ -10,6 +10,23 @@
 #       -D am_version=1.7 \
 #       -D driver_name=Firefox \
 #       -D server_user=archivematica
+#
+# How to run this test against a docker-compose deploy (see
+# https://github.com/artefactual-labs/am)::
+#
+#     $ behave --tags=aip-encrypt-mirror \
+#       --no-skipped \
+#       -D am_version=1.7 \
+#       -D driver_name=Firefox \
+#       -D am_username=test \
+#       -D am_password=test \
+#       -D am_url=http://127.0.0.1:62080/ \
+#       -D am_api_key=test \
+#       -D ss_username=test \
+#       -D ss_password=test \
+#       -D ss_url=http://127.0.0.1:62081/ \
+#       -D home=archivematica \
+#       -D docker_compose_path=/path/to/compose/dir
 
 @aip-encrypt-mirror @am17
 Feature: AIP Encryption via Mirror Locations

--- a/features/core/aip-encryption-mirror.feature
+++ b/features/core/aip-encryption-mirror.feature
@@ -59,4 +59,6 @@ Feature: AIP Encryption via Mirror Locations
     And the master AIP on disk is not encrypted
     And the replica AIP on disk is encrypted
     When the user downloads the replica AIP
+    And the user downloads the master AIP
     Then the downloaded replica AIP is not encrypted
+    And the master and replica AIPs are byte-for-byte identical

--- a/features/core/aip-encryption.feature
+++ b/features/core/aip-encryption.feature
@@ -51,6 +51,7 @@ Feature: AIP Encryption
     And standard AIP-creation decisions are made
     And the user waits for the "Store AIP location" decision point to appear and chooses "Store AIP Encrypted in standard Archivematica Directory" during ingest
     And the user waits for the AIP to appear in archival storage
+    And the user queries the API until the AIP has been stored
     Then the uncompressed AIP on disk at /var/archivematica/sharedDirectory/www/AIPsStoreEncrypted/ is encrypted
     When the user downloads the AIP
     Then the downloaded uncompressed AIP is an unencrypted tarfile

--- a/features/core/aip-encryption.feature
+++ b/features/core/aip-encryption.feature
@@ -1,20 +1,22 @@
-# To run this feature against a standard am.git docker-compose deploy:
+# To run this feature file against a Docker-compose deploy of Archivematica (cf.
+# https://github.com/artefactual-labs/am/tree/master/compose)::
 #
-# $ behave \
-#       --tags=aip-encrypt \
-#       --no-skipped \
-#       -v \
-#       -D am_username=test \
-#       -D am_password=test \
-#       -D am_url=http://127.0.0.1:62080/ \
-#       -D am_version=1.7 \
-#       -D am_api_key=test \
-#       -D ss_username=test \
-#       -D ss_password=test \
-#       -D ss_url=http://127.0.0.1:62081/ \
-#       -D ss_api_key=test \
-#       -D home=archivematica \
-#       -D driver_name=Firefox
+#     $ behave \
+#         --tags=aip-encrypt \
+#         --no-skipped \
+#         -v \
+#         -D am_username=test \
+#         -D am_password=test \
+#         -D am_url=http://127.0.0.1:62080/ \
+#         -D am_version=1.7 \
+#         -D am_api_key=test \
+#         -D ss_username=test \
+#         -D ss_password=test \
+#         -D ss_url=http://127.0.0.1:62081/ \
+#         -D ss_api_key=test \
+#         -D home=archivematica \
+#         -D driver_name=Firefox \
+#         -D docker_compose_path=/path/to/compose/dir
 
 @aip-encrypt @am17
 Feature: AIP Encryption

--- a/features/core/metadata-only-aip-reingest.feature
+++ b/features/core/metadata-only-aip-reingest.feature
@@ -25,7 +25,7 @@ Feature: Metadata-only AIP re-ingest
   Scenario: Isla creates an AIP, and then performs a metadata-only re-ingest on it, adds metadata to it, and confirms that her newly added metadata are in the modified METS file.
     Given that the user has ensured that the default processing config is in its default state
     And the reminder to add metadata is enabled
-    When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer
+    When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/Images/pictures
     And the user waits for the "Assign UUIDs to directories?" decision point to appear and chooses "No" during transfer
     And the user waits for the "Select file format identification command" decision point to appear and chooses "Identify using Fido" during transfer
     And the user waits for the "Perform policy checks on originals?" decision point to appear and chooses "No" during transfer
@@ -39,7 +39,7 @@ Feature: Metadata-only AIP re-ingest
     And the user waits for the "Bind PIDs?" decision point to appear and chooses "No" during ingest
     And the user waits for the "Store AIP (review)" decision point to appear during ingest
     Then in the METS file the metsHdr element has a CREATEDATE attribute but no LASTMODDATE attribute
-    And in the METS file the metsHdr element has two dmdSec next sibling element(s)
+    And in the METS file the metsHdr element has one dmdSec next sibling element(s)
     When the user chooses "Store AIP" at decision point "Store AIP (review)" during ingest
     And the user waits for the "Store AIP location" decision point to appear and chooses "Store AIP in standard Archivematica Directory" during ingest
     And the user waits for the AIP to appear in archival storage
@@ -55,6 +55,6 @@ Feature: Metadata-only AIP re-ingest
     And the user waits for the "Bind PIDs?" decision point to appear and chooses "No" during ingest
     And the user waits for the "Store AIP (review)" decision point to appear during ingest
     Then in the METS file the metsHdr element has a CREATEDATE attribute and a LASTMODDATE attribute
-    And in the METS file the metsHdr element has three dmdSec next sibling element(s)
+    And in the METS file the metsHdr element has two dmdSec next sibling element(s)
     And in the METS file the dmdSec element contains the metadata added
 

--- a/features/core/premis-events.feature
+++ b/features/core/premis-events.feature
@@ -1,3 +1,22 @@
+# How to run this test against a docker-compose deploy (see
+# https://github.com/artefactual-labs/am)::
+#
+#    $ behave \
+#          --tags=premis-events \
+#          --no-skipped \
+#          -v \
+#          -D am_username=test \
+#          -D am_password=test \
+#          -D am_url=http://127.0.0.1:62080/ \
+#          -D am_version=1.7 \
+#          -D am_api_key=test \
+#          -D ss_username=test \
+#          -D ss_password=test \
+#          -D ss_url=http://127.0.0.1:62081/ \
+#          -D ss_api_key=test \
+#          -D home=archivematica \
+#          -D driver_name=Firefox
+#
 @premis-events @am16
 Feature: PREMIS events are recorded correctly
   Users of Archivematica want to be sure that the steps taken by
@@ -8,25 +27,35 @@ Feature: PREMIS events are recorded correctly
   Scenario: Isla wants to confirm that standard PREMIS events are created
   Given that the user has ensured that the default processing config is in its default state
   And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Fido"
+  And the processing config decision "Assign UUIDs to directories" is set to "No"
+  And the processing config decision "Perform policy checks on originals" is set to "No"
   And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
   And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Fido"
   And the processing config decision "Normalize" is set to "Do not normalize"
   And the processing config decision "Approve normalization" is set to "Yes"
+  And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
+  And the processing config decision "Perform policy checks on access derivatives" is set to "No"
+  And the processing config decision "Bind PIDs" is set to "No"
   And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Fido"
   When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer
   And the user waits for the "Store AIP (review)" decision point to appear during ingest
   Then in the METS file there are/is 7 PREMIS event(s) of type ingestion
   And in the METS file there are/is 7 PREMIS event(s) of type message digest calculation with properties {"eventDetail": [["contains", "program=\"python\""], ["contains", "module=\"hashlib.sha256()\""]], "eventOutcomeInformation/eventOutcomeDetail/eventOutcomeDetailNote": [["regex", "^[a-f0-9]+$"]]}
-  And in the METS file there are/is 7 PREMIS event(s) of type virus check with properties {"eventDetail": [["contains",  "program=\"Clam AV\""]], "eventOutcomeInformation/eventOutcome": [["equals", "Pass"]]}
+  And in the METS file there are/is 7 PREMIS event(s) of type virus check with properties {"eventDetail": [["contains",  "program=\"ClamAV"]], "eventOutcomeInformation/eventOutcome": [["equals", "Pass"]]}
 
   @package
   Scenario: Isla wants to confirm that an unpacking PREMIS event is created when a package is ingested
   Given that the user has ensured that the default processing config is in its default state
   And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Fido"
+  And the processing config decision "Assign UUIDs to directories" is set to "No"
+  And the processing config decision "Perform policy checks on originals" is set to "No"
   And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
   And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Fido"
   And the processing config decision "Normalize" is set to "Do not normalize"
   And the processing config decision "Approve normalization" is set to "Yes"
+  And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
+  And the processing config decision "Perform policy checks on access derivatives" is set to "No"
+  And the processing config decision "Bind PIDs" is set to "No"
   And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Fido"
   When a transfer is initiated on directory ~/archivematica-sampledata/TestTransfers/Unicode
   And the user waits for the "Store AIP (review)" decision point to appear during ingest
@@ -36,10 +65,15 @@ Feature: PREMIS events are recorded correctly
   Scenario: Isla wants to confirm that a registration PREMIS event is created when an accession number is provided with a transfer
   Given that the user has ensured that the default processing config is in its default state
   And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Fido"
+  And the processing config decision "Assign UUIDs to directories" is set to "No"
+  And the processing config decision "Perform policy checks on originals" is set to "No"
   And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
   And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Fido"
   And the processing config decision "Normalize" is set to "Do not normalize"
   And the processing config decision "Approve normalization" is set to "Yes"
+  And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
+  And the processing config decision "Perform policy checks on access derivatives" is set to "No"
+  And the processing config decision "Bind PIDs" is set to "No"
   And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Fido"
   When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer with accession number 1234-567
   And the user waits for the "Store AIP (review)" decision point to appear during ingest
@@ -49,10 +83,15 @@ Feature: PREMIS events are recorded correctly
   Scenario: Isla wants to confirm that quarantine PREMIS events are created when files are put under quarantine
   Given that the user has ensured that the default processing config is in its default state
   And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Fido"
+  And the processing config decision "Assign UUIDs to directories" is set to "No"
+  And the processing config decision "Perform policy checks on originals" is set to "No"
   And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
   And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Fido"
   And the processing config decision "Normalize" is set to "Do not normalize"
   And the processing config decision "Approve normalization" is set to "Yes"
+  And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
+  And the processing config decision "Perform policy checks on access derivatives" is set to "No"
+  And the processing config decision "Bind PIDs" is set to "No"
   And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Fido"
   And the processing config decision "Send transfer to quarantine" is set to "None"
   When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer
@@ -66,10 +105,15 @@ Feature: PREMIS events are recorded correctly
   Scenario: Isla wants to confirm that quarantine PREMIS events are created when files are put under quarantine
   Given that the user has ensured that the default processing config is in its default state
   And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Siegfried"
+  And the processing config decision "Assign UUIDs to directories" is set to "No"
+  And the processing config decision "Perform policy checks on originals" is set to "No"
   And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
   And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Siegfried"
   And the processing config decision "Normalize" is set to "Do not normalize"
   And the processing config decision "Approve normalization" is set to "Yes"
+  And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
+  And the processing config decision "Perform policy checks on access derivatives" is set to "No"
+  And the processing config decision "Bind PIDs" is set to "No"
   And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Siegfried"
   When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer
   And the user waits for the "Store AIP (review)" decision point to appear during ingest

--- a/features/core/transfer-policy-check.feature
+++ b/features/core/transfer-policy-check.feature
@@ -22,6 +22,6 @@ Feature: Transfer policy check
     Then the transfer logs directory of the AIP contains a MediaConch policy check output file for each policy file tested against <policy_file>
 
   Examples: Policy Check Outcomes
-    | do_files_conform | microservice_output    | event_outcome  | verification_result | transfer_path                          | policy_file                       | purpose                                  |
-    | conform          | Completed successfully | pass           | successful          | preforma/all-conform-policy-originals  | NYULibraries_MKVFFV1-MODIFIED.xsl | Validation of Originals against a Policy |
-    | not conform      | Failed                 | fail           | failed              | preforma/none-conform-policy-originals | NYULibraries_MKVFFV1-MODIFIED.xsl | Validation of Originals against a Policy |
+    | do_files_conform | microservice_output    | event_outcome  | verification_result | transfer_path                          | policy_file                       | purpose                     |
+    | conform          | Completed successfully | pass           | successful          | preforma/all-conform-policy-originals  | NYULibraries_MKVFFV1-MODIFIED.xsl | Validation against a policy |
+    | not conform      | Failed                 | fail           | failed              | preforma/none-conform-policy-originals | NYULibraries_MKVFFV1-MODIFIED.xsl | Validation against a policy |

--- a/features/core/uuids-for-directories.feature
+++ b/features/core/uuids-for-directories.feature
@@ -1,6 +1,50 @@
-# To run::
-#     $ behave --tags=uuids-dirs --no-skipped -D driver_name=Firefox -D am_version=1.7
-@uuids-dirs @dev
+# To run this feature file against a Docker-compose deploy of Archivematica (cf.
+# https://github.com/artefactual-labs/am/tree/master/compose)::
+#
+#     $ behave \
+#           --tags=uuids-dirs \
+#           -D am_url=http://127.0.0.1:62080/ \
+#           -D ss_url=http://127.0.0.1:62081/ \
+#           -D am_username=test \
+#           -D am_password=test \
+#           -D ss_username=test \
+#           -D ss_password=test \
+#           --no-skipped \
+#           -D driver_name=Firefox \
+#           -D transfer_source_path=archivematica/archivematica-sampledata/TestTransfers/acceptance-tests \
+#           -D am_version=1.7 \
+#           -D docker_compose_path=/home/jdunham/Development/Archivematica/am/compose/ \
+#           -D home=archivematica
+#
+# Warning: the uuids-for-directories.feature is not idempotent. That is, you
+# cannot run it more than once and expect it to pass. This is because it
+# involves starting a Zipped Bag type transfer and such transfers cannot be
+# given unique names using Archivematica: their names are based on the basename
+# of the .zip file used as the transfer source. Therefore, in order to run this
+# feature multiple times, you have to close all transfers and ingests (or at
+# least the ones named "BagTransfer"). You can do this with the following two
+# commands:
+#
+#     $ ./close_all_transfers.sh \
+#           -D am_url=http://127.0.0.1:62080/ \
+#           -D ss_url=http://127.0.0.1:62081/ \
+#           -D am_username=test \
+#           -D am_password=test \
+#           -D ss_username=test \
+#           -D ss_password=test \
+#           -D driver_name=Firefox \
+#           -D am_version=1.7
+#     $ ./close_all_ingests.sh \
+#           -D am_url=http://127.0.0.1:62080/ \
+#           -D ss_url=http://127.0.0.1:62081/ \
+#           -D am_username=test \
+#           -D am_password=test \
+#           -D ss_username=test \
+#           -D ss_password=test \
+#           -D driver_name=Firefox \
+#           -D am_version=1.7
+
+@uuids-dirs
 Feature: UUIDs for Directories
   Sometimes Archivematica users want to be able to treat the directories in a
   transfer as intellectual entities. They want to be able to assign identifiers

--- a/features/steps/aip_encryption_steps.py
+++ b/features/steps/aip_encryption_steps.py
@@ -200,12 +200,20 @@ def step_impl(context):
     the_aip = the_aips[0]
     replica = not_the_aips[0]
     replica_uuid = replica['uuid']
-    assert the_aip['replicas'] == replica['uuid']
+    assert the_aip['replicas'] == replica['uuid'], (
+        'We expected {} and {} to be the same, but they are not the same.'.format(
+            the_aip['replicas'], replica['uuid']))
     assert replica['is_replica_of'] == the_aip['uuid']
-    assert (set([x.strip() for x in replica['actions'].split()]) ==
-            set(['Download']))
-    assert (set([x.strip() for x in the_aip['actions'].split()]) ==
-            set(['Download', 'Re-ingest']))
+    expected_replica_actions = set(['Download', 'Request', 'Deletion'])
+    replica_actions = set([x.strip() for x in replica['actions'].split()])
+    assert replica_actions == expected_replica_actions, (
+        'We expected the replica actions to be {} but in fact they were {}'.format(
+            expected_replica_actions, replica_actions))
+    expected_aip_actions = set(['Download', 'Request', 'Deletion', 'Re-ingest'])
+    aip_actions = set([x.strip() for x in the_aip['actions'].split()])
+    assert aip_actions == expected_aip_actions, (
+        'We expected the AIP actions to be {} but in fact they were {}'.format(
+            expected_aip_actions, aip_actions))
     context.scenario.master_aip_uuid = the_aip_uuid
     context.scenario.replica_aip_uuid = replica_uuid
 

--- a/features/steps/aip_encryption_steps.py
+++ b/features/steps/aip_encryption_steps.py
@@ -390,8 +390,12 @@ def step_impl(context):
         context.scenario.transfer_uuid)
     utils.logger.info('expecting encrypted transfer to be at %s on server',
                       path_on_disk)
-    dip_local_path = context.am_user.ssh.scp_server_file_to_local(
-        path_on_disk)
+    if getattr(context.am_user.docker, 'docker_compose_path', None):
+        dip_local_path = context.am_user.docker.cp_server_file_to_local(
+            path_on_disk)
+    else:
+        dip_local_path = context.am_user.ssh.scp_server_file_to_local(
+            path_on_disk)
     if dip_local_path is None:
         utils.logger.info(
             'Unable to copy file %s from the server to the local file'

--- a/features/steps/aip_encryption_steps.py
+++ b/features/steps/aip_encryption_steps.py
@@ -363,6 +363,9 @@ def step_impl(context, aip_description):
     assert os.path.isdir(context.scenario.aip_path)
 
 
+use_step_matcher('parse')
+
+
 @then('the master and replica AIPs are byte-for-byte identical')
 def step_impl(context):
     assert os.path.isfile(context.scenario.master_aip)
@@ -393,9 +396,6 @@ def step_impl(context, key_name):
         'Import failed. The GPG key provided requires a passphrase. GPG keys'
         ' with passphrases cannot be imported')
     assert not context.am_user.browser.get_gpg_key_search_matches(key_name)
-
-
-use_step_matcher('parse')
 
 
 @then('the transfer on disk is encrypted')
@@ -443,8 +443,12 @@ def step_impl(context, aips_store_path):
     aip_server_path = '{}{}/{}-{}'.format(
         aips_store_path, subpath, context.scenario.transfer_name,
         context.scenario.sip_uuid)
-    aip_local_path = context.am_user.ssh.scp_server_file_to_local(
-        aip_server_path)
+    if getattr(context.am_user.docker, 'docker_compose_path', None):
+        aip_local_path = context.am_user.docker.cp_server_file_to_local(
+            aip_server_path)
+    else:
+        aip_local_path = context.am_user.ssh.scp_server_file_to_local(
+            aip_server_path)
     if aip_local_path is None:
         utils.logger.info(
             'Unable to copy file %s from the server to the local file'

--- a/features/steps/aip_encryption_steps.py
+++ b/features/steps/aip_encryption_steps.py
@@ -189,7 +189,9 @@ def step_impl(context):
     """
     the_aip_uuid = utils.get_uuid_val(context, 'sip')
     search_results = context.scenario.aip_search_results
-    assert len(search_results) == 2
+    assert len(search_results) == 2, (
+        'We expected 2 search results but there are {} in {}'.format(
+            len(search_results), str(search_results)))
     the_aips = [dct for dct in search_results if dct['uuid'] == the_aip_uuid]
     not_the_aips = [dct for dct in search_results
                     if dct['uuid'] != the_aip_uuid]
@@ -351,6 +353,17 @@ def step_impl(context, aip_description):
     context.scenario.aip_path = context.am_user.decompress_aip(
         context.scenario.aip_path)
     assert os.path.isdir(context.scenario.aip_path)
+
+
+@then('the master and replica AIPs are byte-for-byte identical')
+def step_impl(context):
+    assert os.path.isfile(context.scenario.master_aip)
+    assert os.path.isfile(context.scenario.replica_aip)
+    with open(context.scenario.master_aip, 'rb') as filei:
+        master_bytes = filei.read()
+    with open(context.scenario.replica_aip, 'rb') as filei:
+        replica_bytes = filei.read()
+    assert master_bytes == replica_bytes
 
 
 @then('the downloaded uncompressed AIP is an unencrypted tarfile')

--- a/features/steps/mediaconch_steps.py
+++ b/features/steps/mediaconch_steps.py
@@ -63,6 +63,8 @@ def step_impl(context):
     context.execute_steps(
         'Given that the user has ensured that the default processing config is'
         ' in its default state\n'
+        'And the processing config decision "Assign UUIDs to directories" is'
+        ' set to "No"\n'
         'And the processing config decision "Perform policy checks on'
         ' preservation derivatives" is set to "No"\n'
         'And the processing config decision "Perform policy checks on access'
@@ -78,6 +80,7 @@ def step_impl(context):
         'And the processing config decision "Select file format identification'
         ' command (Submission documentation & metadata)" is set to'
         ' "Identify using Fido"\n'
+        'And the processing config decision "Bind PIDs" is set to "No"\n'
         'And the processing config decision "Store AIP location" is set to'
         ' "Store AIP in standard Archivematica Directory"\n'
         'And the processing config decision "Upload DIP" is set to'

--- a/features/steps/mediaconch_steps.py
+++ b/features/steps/mediaconch_steps.py
@@ -189,7 +189,7 @@ def step_impl(context, transfer_path, do_files_conform, policy_file):
     pass
 
 
-@given('an FPR rule with purpose "{purpose}", format "{format}", and command'
+@given('an FPR rule with purpose "{purpose}", format "{format_}", and command'
        ' "{command}"')
 def step_impl(context, purpose, format_, command):
     context.am_user.browser.ensure_fpr_rule(purpose, format_, command)

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -408,6 +408,8 @@ def step_impl(context):
         ' and chooses "Identify using Fido" during ingest\n'
         'And the user waits for the "Bind PIDs?" decision point to appear'
         ' and chooses "No" during ingest\n'
+        'And the user waits for the "Document empty directories?" decision'
+        ' point to appear and chooses "No" during ingest\n'
         'And the user waits for the "Store AIP (review)" decision point to'
         ' appear and chooses "Store AIP" during ingest\n'
         'And the user waits for the "Store AIP location" decision point to'

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -248,8 +248,8 @@ def step_impl(context, aip_description):
     context.scenario.aip_path = context.am_user.api.download_aip(
         transfer_name, uuid_val, context.am_user.browser.ss_api_key)
     attr_name = aip_description.replace(' ', '')
-    utils.logger.info('setting attribute {} to {}'.format(
-        attr_name, context.scenario.aip_path))
+    utils.logger.info('setting attribute %s to %s',
+                      attr_name, context.scenario.aip_path)
     setattr(context.scenario, attr_name, context.scenario.aip_path)
 
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -226,6 +226,7 @@ def step_impl(context):
 
 @when('the user searches for the AIP UUID in the Storage Service')
 def step_impl(context):
+    time.sleep(1)
     the_aip_uuid = utils.get_uuid_val(context, 'sip')
     context.scenario.aip_search_results = (
         context.am_user.browser.search_for_aip_in_storage_service(the_aip_uuid))
@@ -246,6 +247,10 @@ def step_impl(context, aip_description):
     transfer_name = context.scenario.transfer_name
     context.scenario.aip_path = context.am_user.api.download_aip(
         transfer_name, uuid_val, context.am_user.browser.ss_api_key)
+    attr_name = aip_description.replace(' ', '')
+    utils.logger.info('setting attribute {} to {}'.format(
+        attr_name, context.scenario.aip_path))
+    setattr(context.scenario, attr_name, context.scenario.aip_path)
 
 
 use_step_matcher('parse')

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -221,6 +221,7 @@ def step_impl(context, choice, decision_point, unit_type):
 def step_impl(context):
     uuid_val = utils.get_uuid_val(context, 'sip')
     context.am_user.browser.wait_for_aip_in_archival_storage(uuid_val)
+    time.sleep(2)
 
 
 @when('the user searches for the AIP UUID in the Storage Service')

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -344,6 +344,8 @@ def step_impl(context):
         ' appear and chooses "Identify using Siegfried" during ingest\n'
         'And the user waits for the "Bind PIDs?" decision point to appear and'
         ' chooses "No" during ingest\n'
+        'And the user waits for the "Document empty directories?" decision'
+        ' point to appear and chooses "No" during ingest\n'
         'And the user waits for the "Store AIP (review)" decision point to'
         ' appear and chooses "Store AIP" during ingest'
     )

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -253,7 +253,7 @@ def unzip(zip_path):
     zip_ref = zipfile.ZipFile(zip_path, 'r')
     try:
         zip_ref.extractall(directory_to_extract_to)
-    except:
+    except BaseException:
         pass
     finally:
         zip_ref.close()

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 import os
 import re
+import zipfile
 
 
 logger = logging.getLogger(__file__)
@@ -245,3 +246,17 @@ def get_duration_as_float(duration_string):
         hours=dt.hour, minutes=dt.minute, seconds=dt.second,
         microseconds=dt.microsecond)
     return delta.total_seconds()
+
+
+def unzip(zip_path):
+    directory_to_extract_to = os.path.dirname(zip_path)
+    zip_ref = zipfile.ZipFile(zip_path, 'r')
+    try:
+        zip_ref.extractall(directory_to_extract_to)
+    except:
+        pass
+    finally:
+        zip_ref.close()
+    if os.path.isdir(directory_to_extract_to):
+        return directory_to_extract_to
+    return None

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -109,7 +109,7 @@ def assert_premis_event(event_type, event, context):
         event_outcome = event.find(
             'premis:eventOutcomeInformation/premis:eventOutcome',
             context.am_user.mets.mets_nsmap).text
-        assert 'program="Clam AV"' in event_detail
+        assert 'program="ClamAV' in event_detail
         assert event_outcome == 'Pass'
 
 

--- a/features/steps/uuids_for_directories_steps.py
+++ b/features/steps/uuids_for_directories_steps.py
@@ -23,33 +23,40 @@ def step_impl(context, dir_path):
     record the directory structure in ``context``.
     """
     if dir_path.startswith('~/'):
-        dir_path = dir_path[2:]
+        dir_path = '/home/{}/{}'.format(context.HOME, dir_path[2:])
 
     dir_is_zipped = bool(os.path.splitext(dir_path)[1])
     if dir_is_zipped:
-        local_path = context.am_user.ssh.scp_server_file_to_local(
-            dir_path)
+        if getattr(context.am_user.docker, 'docker_compose_path', None):
+            local_path = context.am_user.docker.cp_server_file_to_local(
+                dir_path)
+        else:
+            local_path = context.am_user.ssh.scp_server_file_to_local(
+                dir_path)
     else:
-        local_path = context.am_user.ssh.scp_server_dir_to_local(
-            dir_path)
+        if getattr(context.am_user.docker, 'docker_compose_path', None):
+            local_path = context.am_user.docker.cp_server_dir_to_local(dir_path)
+        else:
+            local_path = context.am_user.ssh.scp_server_dir_to_local(dir_path)
     if local_path is None:
         msg = (
             'Unable to copy item {} from the server to the local file'
-            ' system. Server is not accessible via SSH.'.format(dir_path))
+            ' system.'.format(dir_path))
         utils.logger.warning(msg)
         raise Exception(msg)
     elif local_path is False:
         msg = (
             'Unable to copy item {} from the server to the local file'
-            ' system. Attempt to scp the file failed.'.format(dir_path))
+            ' system. Attempt to copy the file/dir failed.'.format(dir_path))
         utils.logger.warning(msg)
         raise Exception(msg)
     dir_local_path = local_path
     if dir_is_zipped:
-        dir_local_path = context.utils.unzip(local_path)
+        dir_local_path = utils.unzip(local_path)
     assert os.path.isdir(dir_local_path)
     non_root_paths = []
     non_root_file_paths = []
+    empty_dirs = []
 
     # These are the names of the files that Archivematica will remove by
     # default. See MCPClient/lib/settings/common.py,
@@ -58,12 +65,15 @@ def step_impl(context, dir_path):
     to_be_removed_files = [
         e.strip() for e in 'Thumbs.db, Icon, Icon\r, .DS_Store'.split(',')]
 
-    for path, _, files in os.walk(dir_local_path):
+    for path, dirs, files in os.walk(dir_local_path):
         if path != dir_local_path:
             path = path.replace(dir_local_path, '', 1)
             non_root_paths.append(path)
-            non_root_file_paths += [os.path.join(path, file_) for file_ in
-                                    files if file_ not in to_be_removed_files]
+            files = [os.path.join(path, file_) for file_ in
+                     files if file_ not in to_be_removed_files]
+            non_root_file_paths += files
+            if (not dirs) and (not files):
+                empty_dirs.append(path)
 
     if dir_is_zipped:
         # If the "directory" from the server was a zip file, assume it is a
@@ -76,6 +86,7 @@ def step_impl(context, dir_path):
     assert non_root_file_paths
     context.scenario.remote_dir_subfolders = non_root_paths
     context.scenario.remote_dir_files = non_root_file_paths
+    context.scenario.remote_dir_empty_subfolders = empty_dirs
 
 
 @given('a processing configuration that assigns UUIDs to directories')
@@ -106,6 +117,8 @@ def step_impl(context):
         ' derivatives" is set to "No"\n'
         'And the processing config decision "Perform policy checks on'
         ' originals" is set to "No"\n'
+        'And the processing config decision "Document empty directories"'
+        ' is set to "Yes"\n'
     )
 
 
@@ -127,55 +140,89 @@ def step_impl(context):
 
         context.scenario.remote_dir_subfolders
         context.scenario.remote_dir_files
+        context.scenario.remote_dir_empty_subfolders
 
     NOTE: empty directories in the transfer are not indicated in the resulting
     AIP METS.
     """
     context.scenario.mets = mets = utils.get_mets_from_scenario(context)
     ns = context.am_user.mets.mets_nsmap
-    struct_map_el = mets.find('.//mets:structMap[@TYPE="physical"]', ns)
-    subpaths = utils.get_subpaths_from_struct_map(struct_map_el, ns)
-    subpaths = [p.replace('/objects', '', 1) for p in
-                filter(None, utils.remove_common_prefix(subpaths))]
-    for dirpath in context.scenario.remote_dir_subfolders:
-        assert dirpath in subpaths, (
-            'Expected directory path\n{}\nis not in METS structmap'
-            ' paths\n{}'.format(dirpath, pprint.pformat(subpaths)))
-    for filepath in context.scenario.remote_dir_files:
-        if os.path.basename(filepath) == '.gitignore':
-            continue
-        assert filepath in subpaths, (
-            'Expected file path\n{}\nis not in METS structmap'
-            ' paths\n{}'.format(filepath, pprint.pformat(subpaths)))
+    for type_, xpath in (
+            ('physical', './/mets:structMap[@TYPE="physical"]'),
+            ('logical',
+             './/mets:structMap[@LABEL="Normative Directory Structure"]')):
+        struct_map_el = mets.find(xpath, ns)
+        assert struct_map_el is not None, (
+            'We expected to find a {}-type structMap but did not'.format(type_))
+        subpaths = utils.get_subpaths_from_struct_map(struct_map_el, ns)
+        subpaths = [p.replace('/objects', '', 1) for p in
+                    filter(None, utils.remove_common_prefix(subpaths))]
+        for dirpath in context.scenario.remote_dir_subfolders:
+            if ((type_ == 'physical') and
+                    (dirpath in context.scenario.remote_dir_empty_subfolders)):
+                continue
+            assert dirpath in subpaths, (
+                'Expected directory path\n{}\nis not in METS structmap'
+                ' paths\n{}'.format(dirpath, pprint.pformat(subpaths)))
+        if type == 'physical':
+            for filepath in context.scenario.remote_dir_files:
+                if os.path.basename(filepath) == '.gitignore':
+                    continue
+                assert filepath in subpaths, (
+                    'Expected file path\n{}\nis not in METS structmap'
+                    ' paths\n{}'.format(filepath, pprint.pformat(subpaths)))
 
 
 @then('the UUIDs for the subfolders and digital objects are written to the METS'
       ' file')
 def step_impl(context):
+    """Make the following assertions:
+    - All directories are listed in the logical (Normative Directory Structure)
+      structMap.
+    - All directories except for the empty one(s) are listed in the physical
+      structMap.
+    - All non-empty directories in the physical structMap link to a dmdSec that
+      documents the directory's UUID identifier.
+    - All empty directories in the logical structMap link to a dmdSec that
+      documents the directory's UUID identifier.
+    """
     mets = context.scenario.mets
     ns = context.am_user.mets.mets_nsmap
-    struct_map_el = mets.find('.//mets:structMap[@TYPE="physical"]', ns)
-    for dirpath in context.scenario.remote_dir_subfolders:
-        dirname = os.path.basename(dirpath)
-        mets_div_el = struct_map_el.find(
-            './/mets:div[@LABEL="{}"]'.format(dirname), ns)
-        assert mets_div_el is not None, (
-            'Could not find a <mets:div> for directory at {}'.format(
-                dirpath))
-        dmdid = mets_div_el.get('DMDID')
-        dmdSec_el = mets.find('.//mets:dmdSec[@ID="{}"]'.format(dmdid), ns)
-        assert dmdSec_el is not None, (
-            'Could not find a <mets:dmdSec> for directory at {}'.format(
-                dirpath))
-        try:
-            id_type = dmdSec_el.find('.//premis3:objectIdentifierType', ns).text.strip()
-            id_val = dmdSec_el.find('.//premis3:objectIdentifierValue', ns).text.strip()
-        except AttributeError:
-            utils.logger.info(ns)
-            msg = etree.tostring(dmdSec_el, pretty_print=True)
-            print(msg)
-            utils.logger.info(msg)
-            #raise AssertionError('Unable to find objectIdentifierType/Value')
-            raise
-        assert id_type == 'UUID'
-        assert utils.is_uuid(id_val)
+    for type_, xpath in (
+            ('physical', './/mets:structMap[@TYPE="physical"]'),
+            ('logical',
+             './/mets:structMap[@LABEL="Normative Directory Structure"]')):
+        struct_map_el = mets.find(xpath, ns)
+        assert struct_map_el is not None
+        for dirpath in context.scenario.remote_dir_subfolders:
+            if (type_ == 'physical' and
+                    dirpath in context.scenario.remote_dir_empty_subfolders):
+                continue
+            dirname = os.path.basename(dirpath)
+            mets_div_el = struct_map_el.find(
+                './/mets:div[@LABEL="{}"]'.format(dirname), ns)
+            assert mets_div_el is not None, (
+                'Could not find a <mets:div> for directory at {}'.format(
+                    dirpath))
+            if (type_ == 'logical' and
+                    dirpath not in context.scenario.remote_dir_empty_subfolders):
+                continue
+            dmdid = mets_div_el.get('DMDID')
+            dmdSec_el = mets.find('.//mets:dmdSec[@ID="{}"]'.format(dmdid), ns)
+            assert dmdSec_el is not None, (
+                'Could not find a <mets:dmdSec> for directory at {}'.format(
+                    dirpath))
+            try:
+                id_type = dmdSec_el.find('.//premis3:objectIdentifierType', ns).text.strip()
+                id_val = dmdSec_el.find('.//premis3:objectIdentifierValue', ns).text.strip()
+            except AttributeError:
+                utils.logger.info(ns)
+                msg = etree.tostring(dmdSec_el, pretty_print=True)
+                print(msg)
+                utils.logger.info(msg)
+                raise
+            assert id_type == 'UUID'
+            assert utils.is_uuid(id_val)
+            utils.logger.info(
+                'Found UUID for directory "%s" in %s-type structmap',
+                dirpath, type_)

--- a/runs.json
+++ b/runs.json
@@ -80,5 +80,20 @@
         "target_features": ["features/Columbia/indexless.feature"],
         "outcome": "pass",
         "runtime": "5m45.541s"
+    }, {
+        "behave_command": "behave --tags=ipc --tags=preservation --tags=nonmanual -D am_url=http://127.0.0.1:62080/ -D ss_url=http://127.0.0.1:62081/ -D am_username=test -D am_password=test -D ss_username=test -D ss_password=test --no-skipped -D driver_name=Firefox -D transfer_source_path=archivematica/archivematica-sampledata/TestTransfers/acceptance-tests -D am_version=1.7",
+        "environment": {
+            "archivematica_version": "1.7.0",
+            "archivematica_branch": "qa/1.x",
+            "archivematica_commit": "e6fc02d83209681140ec17fb166aefae1ed2e7e7",
+            "storage_service_version": "0.11.0",
+            "storage_service_branch": "qa/0.x",
+            "storage_service_commit": "765aeaea5824c3eaaf27e2f5fdefeb7ecab2a4e5",
+            "sampledata_branch": "master",
+            "sampledata_commit": "e24475753852c0e9bee500f8c5c8f198af55ca0f"
+        },
+        "target_features": ["features/core/ingest-policy-check.feature"],
+        "outcome": "pass",
+        "runtime": "4m55.099s"
     }
 ]

--- a/runs.json
+++ b/runs.json
@@ -95,5 +95,20 @@
         "target_features": ["features/core/ingest-policy-check.feature"],
         "outcome": "pass",
         "runtime": "4m55.099s"
+    }, {
+        "behave_command": "behave --tags=ipc --tags=access --tags=nonmanual -D am_url=http://127.0.0.1:62080/ -D ss_url=http://127.0.0.1:62081/ -D am_username=test -D am_password=test -D ss_username=test -D ss_password=test --no-skipped -D driver_name=Firefox -D transfer_source_path=archivematica/archivematica-sampledata/TestTransfers/acceptance-tests -D am_version=1.7",
+        "environment": {
+            "archivematica_version": "1.7.0",
+            "archivematica_branch": "qa/1.x",
+            "archivematica_commit": "e6fc02d83209681140ec17fb166aefae1ed2e7e7",
+            "storage_service_version": "0.11.0",
+            "storage_service_branch": "qa/0.x",
+            "storage_service_commit": "765aeaea5824c3eaaf27e2f5fdefeb7ecab2a4e5",
+            "sampledata_branch": "master",
+            "sampledata_commit": "036be6fdca1dded9c468b9f44998783a00f1adfb"
+        },
+        "target_features": ["features/core/ingest-policy-check.feature"],
+        "outcome": "pass",
+        "runtime": "3m52.176s"
     }
 ]

--- a/runs.json
+++ b/runs.json
@@ -190,5 +190,18 @@
         "target_features": ["features/core/transfer-mkv-conformance.feature"],
         "outcome": "pass",
         "runtime": "3m55.988s"
+    }, {
+        "behave_command": "behave --tags=mo-aip-reingest --no-skipped -v -D am_username=test -D am_password=test -D am_url=http://127.0.0.1:62080/ -D am_version=1.7 -D am_api_key=test -D ss_username=test -D ss_password=test -D ss_url=http://127.0.0.1:62081/ -D ss_api_key=test -D home=archivematica -D driver_name=Firefox",
+        "environment": {
+            "archivematica_version": "1.7.0",
+            "archivematica_branch": "stable/1.7.x",
+            "archivematica_commit": "a986533cda805b59e7ac690cbd2206bb7e29c502",
+            "storage_service_version": "0.11.0",
+            "storage_service_branch": "stable/0.11.x",
+            "storage_service_commit": "183551f106f6b9a68f49e9ce2b3063a1e1923761"
+        },
+        "target_features": ["features/core/metadata-only-aip-reingest.feature"],
+        "outcome": "pass",
+        "runtime": "4m43.840s"
     }
 ]

--- a/runs.json
+++ b/runs.json
@@ -224,5 +224,18 @@
         "target_features": ["features/core/aip-encryption.feature"],
         "outcome": "pass",
         "runtime": "2m7.080s"
+    }, {
+        "behave_command": "behave --tags=aip-encrypt-mirror --no-skipped -D am_version=1.7 -D driver_name=Firefox -D am_username=test -D am_password=test -D am_url=http://127.0.0.1:62080/ -D am_api_key=test -D ss_username=test -D ss_password=test -D ss_url=http://127.0.0.1:62081/ -D home=archivematica -D docker_compose_path=/abs/path/to/dir/containing/compose/file -v",
+        "environment": {
+            "archivematica_version": "1.7.0",
+            "archivematica_branch": "qa/1.x",
+            "archivematica_commit": "e0a4f52e8c3c15340db54e7dd7a5e453d8243172",
+            "storage_service_version": "0.11.0",
+            "storage_service_branch": "stable/0.11.x",
+            "storage_service_commit": "646f76a50223299ee2cded46812797cfb38416aa"
+        },
+        "target_features": ["features/core/aip-encryption-mirror.feature"],
+        "outcome": "pass",
+        "runtime": "4m57.297s"
     }
 ]

--- a/runs.json
+++ b/runs.json
@@ -16,7 +16,8 @@
         "target_features": ["features/core/metadata-only-aip-reingest.feature"],
         "outcome": "fail",
         "outcome_note": "Failed at step ``And the user initiates a metadata-only re-ingest on the AIP``, module am_browser_ability.py, line 148, in ``initiate_reingest`` with error `selenium.common.exceptions.NoSuchElementException: Message: Unable to locate element: div.alert-success`"
-    }, {
+    },
+    {
         "behave_command": "behave --tags=mo-aip-reingest --no-skipped -v -D am_username=test -D am_password=test -D am_url=http://127.0.0.1:62080/ -D am_version=1.7 -D am_api_key=test -D ss_username=test -D ss_password=test -D ss_url=http://127.0.0.1:62081/ -D ss_api_key=test -D home=archivematica -D driver_name=Firefox",
         "environment": {
             "archivematica_version": "1.7.0",
@@ -33,7 +34,8 @@
         "target_features": ["features/core/metadata-only-aip-reingest.feature"],
         "outcome": "pass",
         "runtime": "7m18.599s"
-    }, {
+    },
+    {
         "behave_command": "behave --tags=indexless --no-skipped -v -D am_username=test -D am_password=test -D am_url=http://127.0.0.1:62080/ -D am_version=1.7 -D am_api_key=test -D ss_username=test -D ss_password=test -D ss_url=http://127.0.0.1:62081/ -D ss_api_key=test -D home=archivematica -D driver_name=Firefox -D docker_compose_path=/path/to/dir/containing/docker/compose/file",
         "environment": {
             "archivematica_version": "1.7.0",
@@ -50,7 +52,8 @@
         "target_features": ["features/Columbia/indexless.feature"],
         "outcome": "pass",
         "runtime": "5m29.640s"
-    }, {
+    },
+    {
         "behave_command": "behave -v --tags=indexless --tags=deploy.method.ansible,same-aip,gui --no-skipped -D am_username=test -D am_password=testtest -D am_url=http://192.168.168.192/ -D am_version=1.7 -D ss_username=test -D ss_password=test -D ss_url=http://192.168.168.192:8000/ -D home=vagrant -D driver_name=Firefox -D server_user=vagrant -D server_password=vagrant",
         "environment": {
             "archivematica_version": "1.7.0",
@@ -65,7 +68,8 @@
         "target_features": ["features/Columbia/indexless.feature"],
         "outcome": "pass",
         "runtime": "2m59.847s"
-    }, {
+    },
+    {
         "behave_command": "behave -v --tags=indexless --tags=deploy.method.docker-compose,same-aip,gui --no-skipped -D am_username=test -D am_password=test -D am_url=http://127.0.0.1:62080/ -D am_version=1.7 -D am_api_key=test -D ss_username=test -D ss_password=test -D ss_url=http://127.0.0.1:62081/ -D ss_api_key=test -D home=archivematica -D driver_name=Firefox -D docker_compose_path=/Users/joeldunham/Documents/Artefactual/am/compose",
         "environment": {
             "archivematica_version": "1.7.0",
@@ -80,7 +84,8 @@
         "target_features": ["features/Columbia/indexless.feature"],
         "outcome": "pass",
         "runtime": "5m45.541s"
-    }, {
+    },
+    {
         "behave_command": "behave --tags=ipc --tags=preservation --tags=nonmanual -D am_url=http://127.0.0.1:62080/ -D ss_url=http://127.0.0.1:62081/ -D am_username=test -D am_password=test -D ss_username=test -D ss_password=test --no-skipped -D driver_name=Firefox -D transfer_source_path=archivematica/archivematica-sampledata/TestTransfers/acceptance-tests -D am_version=1.7",
         "environment": {
             "archivematica_version": "1.7.0",
@@ -95,7 +100,8 @@
         "target_features": ["features/core/ingest-policy-check.feature"],
         "outcome": "pass",
         "runtime": "4m55.099s"
-    }, {
+    },
+    {
         "behave_command": "behave --tags=ipc --tags=access --tags=nonmanual -D am_url=http://127.0.0.1:62080/ -D ss_url=http://127.0.0.1:62081/ -D am_username=test -D am_password=test -D ss_username=test -D ss_password=test --no-skipped -D driver_name=Firefox -D transfer_source_path=archivematica/archivematica-sampledata/TestTransfers/acceptance-tests -D am_version=1.7",
         "environment": {
             "archivematica_version": "1.7.0",
@@ -190,7 +196,8 @@
         "target_features": ["features/core/transfer-mkv-conformance.feature"],
         "outcome": "pass",
         "runtime": "3m55.988s"
-    }, {
+    },
+    {
         "behave_command": "behave --tags=mo-aip-reingest --no-skipped -v -D am_username=test -D am_password=test -D am_url=http://127.0.0.1:62080/ -D am_version=1.7 -D am_api_key=test -D ss_username=test -D ss_password=test -D ss_url=http://127.0.0.1:62081/ -D ss_api_key=test -D home=archivematica -D driver_name=Firefox",
         "environment": {
             "archivematica_version": "1.7.0",
@@ -203,5 +210,19 @@
         "target_features": ["features/core/metadata-only-aip-reingest.feature"],
         "outcome": "pass",
         "runtime": "4m43.840s"
+    },
+    {
+        "behave_command": "behave --tags=transfer-backlog --no-skipped -v -D am_username=test -D am_password=test -D am_url=http://127.0.0.1:62080/ -D am_version=1.7 -D am_api_key=test -D ss_username=test -D ss_password=test -D ss_url=http://127.0.0.1:62081/ -D ss_api_key=test -D home=archivematica -D driver_name=Firefox -D docker_compose_path=/abs/path/to/dir/containing/compose/file",
+        "environment": {
+            "archivematica_version": "1.7.0",
+            "archivematica_branch": "qa/1.x",
+            "archivematica_commit": "e0a4f52e8c3c15340db54e7dd7a5e453d8243172",
+            "storage_service_version": "0.11.0",
+            "storage_service_branch": "stable/0.11.x",
+            "storage_service_commit": "61ab193af9e312961ec445121baccc7b052a8a16"
+        },
+        "target_features": ["features/core/aip-encryption.feature"],
+        "outcome": "pass",
+        "runtime": "2m7.080s"
     }
 ]

--- a/runs.json
+++ b/runs.json
@@ -110,5 +110,53 @@
         "target_features": ["features/core/ingest-policy-check.feature"],
         "outcome": "pass",
         "runtime": "3m52.176s"
+    },
+    {
+        "behave_command": "behave --tags=ipc --tags=access --tags=manual -D am_url=http://127.0.0.1:62080/ -D ss_url=http://127.0.0.1:62081/ -D am_username=test -D am_password=test -D ss_username=test -D ss_password=test --no-skipped -D driver_name=Firefox -D transfer_source_path=archivematica/archivematica-sampledata/TestTransfers/acceptance-tests -D am_version=1.7",
+        "environment": {
+            "archivematica_version": "1.7.0",
+            "archivematica_branch": "qa/1.x",
+            "archivematica_commit": "e6fc02d83209681140ec17fb166aefae1ed2e7e7",
+            "storage_service_version": "0.11.0",
+            "storage_service_branch": "qa/0.x",
+            "storage_service_commit": "765aeaea5824c3eaaf27e2f5fdefeb7ecab2a4e5",
+            "sampledata_branch": "master",
+            "sampledata_commit": "036be6fdca1dded9c468b9f44998783a00f1adfb"
+        },
+        "target_features": ["features/core/ingest-policy-check.feature"],
+        "outcome": "pass",
+        "runtime": "3m40.135s"
+    },
+    {
+        "behave_command": "behave --tags=ipc --tags=preservation --tags=manual -D am_url=http://127.0.0.1:62080/ -D ss_url=http://127.0.0.1:62081/ -D am_username=test -D am_password=test -D ss_username=test -D ss_password=test --no-skipped -D driver_name=Firefox -D transfer_source_path=archivematica/archivematica-sampledata/TestTransfers/acceptance-tests -D am_version=1.7",
+        "environment": {
+            "archivematica_version": "1.7.0",
+            "archivematica_branch": "qa/1.x",
+            "archivematica_commit": "e6fc02d83209681140ec17fb166aefae1ed2e7e7",
+            "storage_service_version": "0.11.0",
+            "storage_service_branch": "qa/0.x",
+            "storage_service_commit": "765aeaea5824c3eaaf27e2f5fdefeb7ecab2a4e5",
+            "sampledata_branch": "master",
+            "sampledata_commit": "036be6fdca1dded9c468b9f44998783a00f1adfb"
+        },
+        "target_features": ["features/core/ingest-policy-check.feature"],
+        "outcome": "pass",
+        "runtime": "4m23.489s"
+    },
+    {
+        "behave_command": "behave --tags=ipc -D am_url=http://127.0.0.1:62080/ -D ss_url=http://127.0.0.1:62081/ -D am_username=test -D am_password=test -D ss_username=test -D ss_password=test --no-skipped -D driver_name=Firefox -D transfer_source_path=archivematica/archivematica-sampledata/TestTransfers/acceptance-tests -D am_version=1.7",
+        "environment": {
+            "archivematica_version": "1.7.0",
+            "archivematica_branch": "qa/1.x",
+            "archivematica_commit": "e6fc02d83209681140ec17fb166aefae1ed2e7e7",
+            "storage_service_version": "0.11.0",
+            "storage_service_branch": "qa/0.x",
+            "storage_service_commit": "765aeaea5824c3eaaf27e2f5fdefeb7ecab2a4e5",
+            "sampledata_branch": "master",
+            "sampledata_commit": "036be6fdca1dded9c468b9f44998783a00f1adfb"
+        },
+        "target_features": ["features/core/ingest-policy-check.feature"],
+        "outcome": "pass",
+        "runtime": "16m6.161s"
     }
 ]

--- a/runs.json
+++ b/runs.json
@@ -174,5 +174,21 @@
         "target_features": ["features/core/ingest-mkv-conformance.feature"],
         "outcome": "pass",
         "runtime": "7m8.105s"
+    },
+    {
+        "behave_command": "behave --tags=tcc -D am_url=http://127.0.0.1:62080/ -D ss_url=http://127.0.0.1:62081/ -D am_username=test -D am_password=test -D ss_username=test -D ss_password=test --no-skipped -D driver_name=Firefox -D transfer_source_path=archivematica/archivematica-sampledata/TestTransfers/acceptance-tests -D am_version=1.7",
+        "environment": {
+            "archivematica_version": "1.7.0",
+            "archivematica_branch": "qa/1.x",
+            "archivematica_commit": "e6fc02d83209681140ec17fb166aefae1ed2e7e7",
+            "storage_service_version": "0.11.0",
+            "storage_service_branch": "qa/0.x",
+            "storage_service_commit": "765aeaea5824c3eaaf27e2f5fdefeb7ecab2a4e5",
+            "sampledata_branch": "master",
+            "sampledata_commit": "036be6fdca1dded9c468b9f44998783a00f1adfb"
+        },
+        "target_features": ["features/core/transfer-mkv-conformance.feature"],
+        "outcome": "pass",
+        "runtime": "3m55.988s"
     }
 ]

--- a/runs.json
+++ b/runs.json
@@ -158,5 +158,21 @@
         "target_features": ["features/core/ingest-policy-check.feature"],
         "outcome": "pass",
         "runtime": "16m6.161s"
+    },
+    {
+        "behave_command": "behave --tags=icc -D am_url=http://127.0.0.1:62080/ -D ss_url=http://127.0.0.1:62081/ -D am_username=test -D am_password=test -D ss_username=test -D ss_password=test --no-skipped -D driver_name=Firefox -D transfer_source_path=archivematica/archivematica-sampledata/TestTransfers/acceptance-tests -D am_version=1.7",
+        "environment": {
+            "archivematica_version": "1.7.0",
+            "archivematica_branch": "qa/1.x",
+            "archivematica_commit": "e6fc02d83209681140ec17fb166aefae1ed2e7e7",
+            "storage_service_version": "0.11.0",
+            "storage_service_branch": "qa/0.x",
+            "storage_service_commit": "765aeaea5824c3eaaf27e2f5fdefeb7ecab2a4e5",
+            "sampledata_branch": "master",
+            "sampledata_commit": "036be6fdca1dded9c468b9f44998783a00f1adfb"
+        },
+        "target_features": ["features/core/ingest-mkv-conformance.feature"],
+        "outcome": "pass",
+        "runtime": "7m8.105s"
     }
 ]


### PR DESCRIPTION
This PR contains changes that ensure that (a maximal subset of) these tests can be run against Archivematica version 1.7. In particular, the tests with the changes in this PR have been run against an AM 1.7.x / SS 0.11.x Docker Compose install using the following command (broken up feature-by-feature):

    $ behave \
          --tags=mo-aip-reingest,icc,ipc,tpc,picc,uuids-dirs,premis-events,pid-binding,aip-encrypt-mirror,aip-encrypt \
          --no-skipped \
          -v \
          -D am_version=1.7 \
          -D am_url=http://127.0.0.1:62080/ \
          -D am_username=test \
          -D am_password=test \
          -D am_api_key=test \
          -D ss_url=http://127.0.0.1:62081/ \
          -D ss_username=test \
          -D ss_password=test \
          -D ss_api_key=test \
          -D home=archivematica \
          -D transfer_source_path=archivematica/archivematica-sampledata/TestTransfers/acceptance-tests \
          -D driver_name=Firefox \
          -D docker_compose_path=<ABS_PATH_TO_DIR_CONTAINING_DOCKER_COMPOSE_FILE> \
          -D pid_web_service_endpoint=<SOME_URL> \
          -D pid_web_service_key=<SOME_SECRET> \
          -D handle_resolver_url=<SOME_RESOLVER_URL> \
          -D base_resolve_url=<SOME_RESOLVE_URL> \
          -D pid_xml_namespace=<SOME_NAMESPACE>

This effectively resolves [the AM PR that asks that these tests be run against AM v 1.7 rc3](https://github.com/artefactual/archivematica/issues/942)