### PR TITLE
Add tests for manual normalization with prefix paths

### DIFF
--- a/amuser/constants.py
+++ b/amuser/constants.py
@@ -183,6 +183,8 @@ MICRO_SERVICES2GROUPS = {
     'Prepare AIP': ('Prepare AIP',),
     'Process JSON metadata': ('Process metadata directory',),
     'Process transfer JSON metadata': ('Reformat metadata files',),
+    'Relate manual normalized preservation files to the original files': (
+        'Process manually normalized files',),
     'Reminder: add metadata if desired': ('Add final metadata',),
     'Remove cache files': ('Remove cache files',),
     'Remove empty manual normalization directories': ('Process metadata directory',),

--- a/features/core/manual-normalization.feature
+++ b/features/core/manual-normalization.feature
@@ -1,0 +1,38 @@
+# To run this feature against a Docker Compose-based Archivematica deploy::
+#
+#     $ behave --tags=man-norm \
+#           --no-skipped \
+#           -D am_username=test \
+#           -D am_password=test \
+#           -D am_url=http://127.0.0.1:62080/ \
+#           -D am_version=1.7 \
+#           -D am_api_key=test \
+#           -D ss_username=test \
+#           -D ss_password=test \
+#           -D ss_url=http://127.0.0.1:62081/ \
+#           -D ss_api_key=test \
+#           -D home=archivematica \
+#           -D driver_name=Firefox \
+
+@man-norm
+Feature: Archivematica recognizes manually normalized files
+  Archivematica users want to be able to manually normalize their own files and
+  make sure that Archivematica correctly recognizes and documents the
+  relationship betweeen the originals and the manually normalized files.
+
+  Scenario Outline: Isla wants to create an AIP from a transfer containing manually normalized files, some of which have paths that are prefixes of other manually normalized files.
+    Given a processing configuration for testing manual normalization
+    And transfer source <transfer_path> which contains a manually normalized file whose path is a prefix of another manually normalized file
+    When a transfer is initiated on directory <transfer_path>
+    And the user waits for the "Normalize for preservation" micro-service to complete during ingest
+    Then the "Normalize for preservation" micro-service output is "Completed successfully" during ingest
+    And all preservation tasks recognize the manually normalized derivatives
+    When the user waits for the "Relate manual normalized preservation files to the original files" micro-service to complete during ingest
+    Then the "Relate manual normalized preservation files to the original files" micro-service output is "Completed successfully" during ingest
+    And each manually normalized file is matched to an original
+    When the user waits for the "Generate METS.xml document|Generate AIP METS" micro-service to complete during ingest
+    Then the "Generate METS.xml document|Generate AIP METS" micro-service output is "Completed successfully" during ingest
+
+    Examples: Transfer paths
+    | transfer_path                                                                  |
+    | ~/archivematica-sampledata/TestTransfers/acceptance-tests/manual-normalization |

--- a/features/steps/manual_normalization_steps.py
+++ b/features/steps/manual_normalization_steps.py
@@ -1,0 +1,81 @@
+"""Steps for the Manual Normalization Feature."""
+
+from behave import then, given
+
+# ==============================================================================
+# Step Definitions
+# ==============================================================================
+
+# Givens
+# ------------------------------------------------------------------------------
+
+@given('a processing configuration for testing manual normalization')
+def step_impl(context):
+    """Create a processing configuration that moves a transfer through to
+    "Store AIP" and runs normalization for preservation.
+    """
+    context.execute_steps(
+        'Given that the user has ensured that the default processing config is'
+        ' in its default state\n'
+        'And the processing config decision "Assign UUIDs to directories" is'
+        ' set to "No"\n'
+        'And the processing config decision "Perform policy checks on'
+        ' preservation derivatives" is set to "No"\n'
+        'And the processing config decision "Perform policy checks on access'
+        ' derivatives" is set to "No"\n'
+        'And the processing config decision "Perform policy checks on'
+        ' originals" is set to "No"\n'
+        'And the processing config decision "Select file format identification'
+        ' command (Transfer)" is set to "Identify using Fido"\n'
+        'And the processing config decision "Create SIP(s)" is set to "Create'
+        ' single SIP and continue processing"\n'
+        'And the processing config decision "Normalize" is set to "Normalize'
+        ' for preservation"\n'
+        'And the processing config decision "Approve normalization" is set to'
+        ' "Yes"\n'
+        'And the processing config decision "Select file format identification'
+        ' command (Submission documentation & metadata)" is set to'
+        ' "Identify using Fido"\n'
+        'And the processing config decision "Bind PIDs" is set to "No"\n'
+        'And the processing config decision "Store AIP location" is set to'
+        ' "Store AIP in standard Archivematica Directory"\n'
+        'And the processing config decision "Upload DIP" is set to'
+        ' "Do not upload DIP"\n'
+    )
+
+
+@given('transfer source {transfer_path} which contains a manually normalized'
+       ' file whose path is a prefix of another manually normalized file')
+def step_impl(context, transfer_path):
+    pass
+
+
+# Whens
+# ------------------------------------------------------------------------------
+
+
+# Thens
+# ------------------------------------------------------------------------------
+
+@then('all preservation tasks recognize the manually normalized derivatives')
+def step_impl(context):
+    skipping_msg = ('is file group usage manualNormalization instead of'
+                    '  original  - skipping')
+    already_nmlzd_msg = 'was already manually normalized into'
+    for task in context.scenario.job['tasks'].values():
+        try:
+            assert skipping_msg in task['stdout']
+        except AssertionError:
+            assert already_nmlzd_msg in task['stdout']
+
+
+@then('each manually normalized file is matched to an original')
+def step_impl(context):
+    for task in context.scenario.job['tasks'].values():
+        assert 'Matched original file' in task['stdout']
+        assert 'to  preservation file' in task['stdout']
+
+
+# ==============================================================================
+# Helper Functions
+# ==============================================================================


### PR DESCRIPTION
Tests that [AM issue 972](https://github.com/artefactual/archivematica/issues/972) is fixed by [AM PR 973](https://github.com/artefactual/archivematica/pull/973). The PR make the normalize.py client script more intelligently match manually created preservation derivatives to originals. The test/feature implemented here confirms that manually created derivatives are linked to their originals and that the METS file is successfully created.