### PR TITLE
Modify performance "no stdout" feature

### DIFF
--- a/amuser/am_docker_ability.py
+++ b/amuser/am_docker_ability.py
@@ -48,6 +48,7 @@ class ArchivematicaDockerAbility(base.Base):
             ' LENGTH(t.stdOut) as len_std_out,'
             ' LENGTH(t.stdError) as len_std_err,'
             ' t.exec,'
+            ' t.exitCode,'
             ' t.endTime,'
             ' t.startTime,'
             ' TIMEDIFF(t.endTime,t.startTime) as duration'

--- a/features/core/performance-stdout-no-write.feature
+++ b/features/core/performance-stdout-no-write.feature
@@ -1,18 +1,15 @@
 # Performance Increase Without Output Streams Feature File
 # ==============================================================================
-#
+
 # Warning: this feature file should only be run in development. It requires a
 # docker-compose-based Archivematica deploy. The test itself must be able to
 # alter the deployment by changing an environment variable and recreating a
-# docker container. This feature was developed against an AM deploy created
-# using https://github.com/artefactual-labs/am on branch
-# dev/issue-11443-performance-no-capture-output.
+# docker container.
 #
 # To run the test, deploy Archivematica locally using
 # https://github.com/artefactual-labs/am::
 #
 #     $ git clone https://github.com/artefactual-labs/am
-#     $ git checkout dev/issue-11443-performance-no-capture-output
 #     $ cd am/compose
 #     $ git submodule update --init --recursive
 #     $ make create-volumes
@@ -35,8 +32,6 @@
 #         -D am_version=1.7 \
 #         -D docker_compose_path=/abs/path/to/am/compose
 #         -D home=archivematica
-#
-#     behave --tags=performance-no-stdout --no-skipped --no-capture -D driver_name=Firefox -D am_url=http://127.0.0.1:62080/ -D am_password=test -D home="" -D am_version=1.7 -D docker_compose_path=/Users/joeldunham/Documents/Artefactual/am/compose -D home=archivematica
 
 # Results
 # ==============================================================================
@@ -82,10 +77,28 @@
 # Analysis
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 #
-# Average runtime for without output tasks: 514.10 seconds
-# Average runtime for with output tasks:    535.88 seconds
-# Average time reduction:                     7.18 %
+# Average runtime for without output tasks:  514.10 seconds
+# Average runtime for with output tasks:     535.88 seconds
+# Average time reduction:                      7.18 %
 
+
+# Results against TestTransfers/.../images-17M-each (1.9G)
+# ------------------------------------------------------------------------------
+#
+# This test was run using the modified (and final) version of the feature
+# wherein the CAPTURE_CLIENT_SCRIPT_OUTPUT flag causes stderr to be passed from
+# the gearman worker to the gearman task manager if, and only if, the exit code
+# of the task was non-zero.
+#
+# This transfer contains 113 17M .tif files for a total size of 1.9G.
+#
+# 1. Total runtime for without output tasks: 1,757.50 seconds
+#    Total runtime for with output tasks:    1,905.62 seconds
+#
+# Analysis
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#
+# Average time reduction:                        7.77 %
 
 @performance-no-stdout @developer
 Feature: Performance increase: stop saving stdout/stderr
@@ -113,14 +126,14 @@ Feature: Performance increase: stop saving stdout/stderr
     # Note: this will currently fail because ceasing to pass client script
     # output streams to MCPServer has no effect on what is written to the METS
     # file.
-    And the size of the without_outputs_stats METS file is less than that of the with_outputs_stats METS file
+    # And the size of the without_outputs_stats METS file is less than that of the with_outputs_stats METS file
 
     Examples: Archivematica transfer sources
-    | transfer_source                                                        |
-    #| ~/archivematica-sampledata/TestTransfers/small                        |
-    | ~/archivematica-sampledata/SampleTransfers/Images                     |
-    #| ~/TestTransfers/acceptance-tests/performance/images-17M-each-2G-total |
-    #| ~/TestTransfers/acceptance-tests/performance/video-14M-each-10G-total |
+    | transfer_source                                                                       |
+    #| ~/archivematica-sampledata/TestTransfers/small                                        |
+    #| ~/archivematica-sampledata/SampleTransfers/Images                                     |
+    | ~/archivematica-sampledata/TestTransfers/acceptance-tests/performance/images-17M-each |
+    #| ~/archivematica-sampledata/TestTransfers/acceptance-tests/performance/video-14M-each  |
 
     # Listed below are possible metrics of performance increase. Those checked
     # off are relatively easy to measure and are described in the scenario

--- a/features/steps/performance_stdout_no_write_steps.py
+++ b/features/steps/performance_stdout_no_write_steps.py
@@ -96,7 +96,10 @@ def step_impl(context, without_outputs_fname, with_outputs_fname):
     w_o_sum_tasks = sum(t['duration_float'] for t in with_outputs_tasks)
     utils.logger.info('Total runtime for without output tasks: %f', wo_o_sum_tasks)
     utils.logger.info('Total runtime for with output tasks: %f', w_o_sum_tasks)
-    assert wo_o_sum_tasks < w_o_sum_tasks
+    assert wo_o_sum_tasks < w_o_sum_tasks, (
+        'We expected the runtime {} of the "without output" AIP to be less'
+        ' than the runtime {} of the "with output" AIP but our expectation was'
+        ' not met.'.format(wo_o_sum_tasks, w_o_sum_tasks))
 
 
 @then('performance statistics show output streams {verb} saved to the database')
@@ -105,7 +108,8 @@ def step_impl(context, verb):
     with open(path) as fi:
         stats = json.load(fi)
     std_out_len_set = set([x['len_std_out'] for x in stats['tasks']])
-    std_err_len_set = set([x['len_std_err'] for x in stats['tasks']])
+    std_err_len_set = set([x['len_std_err'] for x in stats['tasks']
+                           if x['exitCode'].strip() == '0'])
     if verb == 'are':
         assert len(std_out_len_set) > 1
         assert len(std_err_len_set) > 1


### PR DESCRIPTION
Modifies the performance-stdout-no-write feature file so that it accounts for the new behaviour of the CAPTURE_CLIENT_SCRIPT_OUTPUT setting of Archivematica (cf. [AM PR 937](https://github.com/artefactual/archivematica/pull/937)). Now, when the aforementioned setting is set to `false`, stdout will never be passed from gearman worker to gearman task manager, but stderr will be passed only if the exit code of the task is non-zero. Running this test confirms that the roughly 6-7% reduction in task execution time is still observed with these changes.