### PR TITLE
Add test for a MediaConch-challenging file

### DIFF
--- a/features/core/mediaconch-challenging-mkv.feature
+++ b/features/core/mediaconch-challenging-mkv.feature
@@ -1,0 +1,41 @@
+# How to run this test against a docker-compose deploy (see
+# https://github.com/artefactual-labs/am)::
+#
+#     $ behave \
+#           --tags=mediaconch-challenging-mkv \
+#           --no-skipped \
+#           -v \
+#           -D am_version=1.7 \
+#           -D am_url=http://127.0.0.1:62080/ \
+#           -D am_username=test \
+#           -D am_password=test \
+#           -D am_api_key=test \
+#           -D ss_url=http://127.0.0.1:62081/ \
+#           -D ss_username=test \
+#           -D ss_password=test \
+#           -D ss_api_key=test \
+#           -D home=archivematica \
+#           -D driver_name=Firefox \
+#
+@mediaconch-challenging-mkv
+Feature: MediaConch validation handles challenging MKV files
+  Archivematica users want to be able to validate .mkv derivatives using
+  MediaConch even when those files have been known to break validation in
+  earlier versions of MediaConch. See
+  https://github.com/artefactual/archivematica/issues/966.
+
+  Scenario Outline: Isla wants to confirm that she can use MediaConch to validate an MKV preservation derivative known to have broken MediaConch validation in earlier versions
+    Given a processing configuration for MediaConch challenging file testing
+    And transfer path <transfer_path> which contains files that, when normalized to MKV, are known to have broken MediaConch v. 16.12 validation checks
+    When a transfer is initiated on directory <transfer_path>
+    And the user waits for the "Identify file format" micro-service to complete during transfer
+    Then the "Identify file format" micro-service output is "Completed successfully" during transfer
+    And all original files in the transfer are identified as PRONOM fmt/199 (MPEG-4 Media File)
+    When the user waits for the "Validate preservation derivatives" micro-service to complete during ingest
+    Then the "Validate preservation derivatives" micro-service output is "Completed successfully" during ingest
+    When the user waits for the "Store AIP (review)" decision point to appear during ingest
+    Then all PREMIS implementation-check-type validation events have eventOutcome = pass
+
+    Examples: Transfer paths
+    | transfer_path                                  |
+    | ~/archivematica-sampledata/mc-challenging-file |

--- a/features/steps/mediaconch_steps.py
+++ b/features/steps/mediaconch_steps.py
@@ -112,6 +112,29 @@ def step_impl(context):
     )
 
 
+@given('a processing configuration for MediaConch challenging file testing')
+def step_impl(context):
+    context.execute_steps(
+        'Given a base processing configuration for MediaConch tests\n'
+        'And the processing config decision "Select file format identification'
+        ' command (Transfer)" is set to "Identify using Siegfried"\n'
+        'And the processing config decision "Normalize" is set to "Normalize'
+        ' for preservation"'
+    )
+
+
+@given('transfer path {transfer_path} which contains files that, when'
+       ' normalized to MKV, are known to have broken MediaConch v. 16.12'
+       ' validation checks')
+def step_impl(context, transfer_path):
+    """We won't confirm it here, but if you attempt to run an implementation
+    check on the .mkv file produced by normalizing the file(s) in this
+    ``transfer_path`` using MediaConch v. 16.12, then MediaConch will hang. See
+    https://github.com/artefactual/archivematica/issues/966.
+    """
+    pass
+
+
 @given('a processing configuration for conformance checks on access'
        ' derivatives')
 def step_impl(context):
@@ -459,6 +482,13 @@ def step_impl(context, event_outcome):
     assert events
     for e in events:
         assert e['event_outcome'] == event_outcome
+
+
+@then('all original files in the transfer are identified as PRONOM fmt/199'
+      ' (MPEG-4 Media File)')
+def step_impl(context):
+    for task in context.scenario.job['tasks'].values():
+        assert 'fmt/199' in task['stdout']
 
 
 # ==============================================================================


### PR DESCRIPTION
Adds a feature that confirms that [AM PR 995](https://github.com/artefactual/archivematica/pull/995) fixes [AM issue 966](https://github.com/artefactual/archivematica/issues/966).

The new feature file mediaconch-challenging-mkv.feature is _ad hoc_ but it confirms that AM with MediaConch 17.12 installed will not hang when attempting to perform an implementation check (validation) on an .mkv file (created from a particular .mp4 file) that _does_ cause MediaConch 16.12 to hang.

Note: the feature in mediaconch-challenging-mkv.feature implicitly requires a directory in archivematica-sampledata/ called mc-challenging-file/ that contains a single .mp4 file called lunchroom_manners_512kb.mp4 which, when normalized to .mkv, will produce a file that makes MediaConch 16.12 but not 17.12 hang when performing an implementation check. The archive containing this file can be found at https://github.com/artefactual/archivematica/issues/966. If possible, the AM-sampledata repo should be modified to include mc-verbosity-test/.