### PR TITLE
Account for new "Document empty directories" decision point

### DIFF
--- a/amuser/am_browser_ability.py
+++ b/amuser/am_browser_ability.py
@@ -468,6 +468,11 @@ class ArchivematicaBrowserAbility(
             self.set_processing_config_decision(
                 decision_label='Bind PIDs',
                 choice_value='None')
+            self.set_processing_config_decision(
+                decision_label='Document empty directories',
+                choice_value='None')
+
+
         self.save_default_processing_config()
 
     # ==========================================================================

--- a/features/core/ingest-mkv-conformance.feature
+++ b/features/core/ingest-mkv-conformance.feature
@@ -25,7 +25,7 @@ Feature: Ingest (i.e., post-normalization) conformance check
     Examples: Normalized for Preservation File Validity Possibilities
     | file_validity | microservice_output    | validation_result | event_outcome | transfer_path                        |
     | valid         | Completed successfully | Passed            | pass          | preforma/when-normalized-all-valid   |
-    | not valid     | Failed                 | Failed            | fail          | preforma/when-normalized-none-valid  |
+    #| not valid     | Failed                 | Failed            | fail          | preforma/when-normalized-none-valid  |
 
   @access
   Scenario Outline: Isla wants to confirm that normalization to .mkv for access is successful

--- a/features/core/metadata-only-aip-reingest.feature
+++ b/features/core/metadata-only-aip-reingest.feature
@@ -15,13 +15,12 @@
 #     -D driver_name=Firefox
 # behave --tags=mo-aip-reingest --no-skipped -v -D am_username=test -D am_password=test -D am_url=http://127.0.0.1:62080/ -D am_version=1.7 -D am_api_key=test -D ss_username=test -D ss_password=test -D ss_url=http://127.0.0.1:62081/ -D ss_api_key=test -D home=archivematica -D driver_name=Firefox
 
-@am16
+@mo-aip-reingest
 Feature: Metadata-only AIP re-ingest
   Users want to be able to take an existing AIP and perform a metadata-only
   re-ingest on it so that they can add metadata to it and confirm that those
   metadata are in the re-ingested AIP's METS file.
 
-  @mo-aip-reingest
   Scenario: Isla creates an AIP, and then performs a metadata-only re-ingest on it, adds metadata to it, and confirms that her newly added metadata are in the modified METS file.
     Given that the user has ensured that the default processing config is in its default state
     And the reminder to add metadata is enabled
@@ -37,6 +36,7 @@ Feature: Metadata-only AIP re-ingest
     And the user waits for the "Reminder: add metadata if desired" decision point to appear and chooses "Continue" during ingest
     And the user waits for the "Select file format identification command|Process submission documentation" decision point to appear and chooses "Identify using Fido" during ingest
     And the user waits for the "Bind PIDs?" decision point to appear and chooses "No" during ingest
+    And the user waits for the "Document empty directories?" decision point to appear and chooses "No" during ingest
     And the user waits for the "Store AIP (review)" decision point to appear during ingest
     Then in the METS file the metsHdr element has a CREATEDATE attribute but no LASTMODDATE attribute
     And in the METS file the metsHdr element has one dmdSec next sibling element(s)
@@ -53,6 +53,7 @@ Feature: Metadata-only AIP re-ingest
     And the user chooses "Continue" at decision point "Reminder: add metadata if desired" during ingest
     And the user waits for the "Select file format identification command|Process submission documentation" decision point to appear and chooses "Identify using Fido" during ingest
     And the user waits for the "Bind PIDs?" decision point to appear and chooses "No" during ingest
+    And the user waits for the "Document empty directories?" decision point to appear and chooses "No" during ingest
     And the user waits for the "Store AIP (review)" decision point to appear during ingest
     Then in the METS file the metsHdr element has a CREATEDATE attribute and a LASTMODDATE attribute
     And in the METS file the metsHdr element has two dmdSec next sibling element(s)

--- a/features/core/pid-binding.feature
+++ b/features/core/pid-binding.feature
@@ -40,7 +40,7 @@ Feature: Archivematica's entities can be assigned PIDs with specified resolution
 
   Scenario Outline: Lucien wants to create an AIP with a METS file that documents the binding of persistent identifiers to all of the AIP's original files and directories, and to the AIP itself.
     Given a fully automated default processing config
-    And default processing configured to assign UUIDs to directories
+    And default processing configured to assign UUIDs to all directories
     And default processing configured to bind PIDs
     And a Handle server client configured to create qualified PURLs
     And a Handle server client configured to use the accession number as the PID for the AIP

--- a/features/core/premis-events.feature
+++ b/features/core/premis-events.feature
@@ -25,97 +25,101 @@ Feature: PREMIS events are recorded correctly
 
   @standard
   Scenario: Isla wants to confirm that standard PREMIS events are created
-  Given that the user has ensured that the default processing config is in its default state
-  And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Fido"
-  And the processing config decision "Assign UUIDs to directories" is set to "No"
-  And the processing config decision "Perform policy checks on originals" is set to "No"
-  And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
-  And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Fido"
-  And the processing config decision "Normalize" is set to "Do not normalize"
-  And the processing config decision "Approve normalization" is set to "Yes"
-  And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
-  And the processing config decision "Perform policy checks on access derivatives" is set to "No"
-  And the processing config decision "Bind PIDs" is set to "No"
-  And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Fido"
-  When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer
-  And the user waits for the "Store AIP (review)" decision point to appear during ingest
-  Then in the METS file there are/is 7 PREMIS event(s) of type ingestion
-  And in the METS file there are/is 7 PREMIS event(s) of type message digest calculation with properties {"eventDetail": [["contains", "program=\"python\""], ["contains", "module=\"hashlib.sha256()\""]], "eventOutcomeInformation/eventOutcomeDetail/eventOutcomeDetailNote": [["regex", "^[a-f0-9]+$"]]}
-  And in the METS file there are/is 7 PREMIS event(s) of type virus check with properties {"eventDetail": [["contains",  "program=\"ClamAV"]], "eventOutcomeInformation/eventOutcome": [["equals", "Pass"]]}
+    Given that the user has ensured that the default processing config is in its default state
+    And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Fido"
+    And the processing config decision "Assign UUIDs to directories" is set to "No"
+    And the processing config decision "Perform policy checks on originals" is set to "No"
+    And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
+    And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Fido"
+    And the processing config decision "Normalize" is set to "Do not normalize"
+    And the processing config decision "Approve normalization" is set to "Yes"
+    And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
+    And the processing config decision "Perform policy checks on access derivatives" is set to "No"
+    And the processing config decision "Bind PIDs" is set to "No"
+    And the processing config decision "Document empty directories" is set to "No"
+    And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Fido"
+    When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer
+    And the user waits for the "Store AIP (review)" decision point to appear during ingest
+    Then in the METS file there are/is 7 PREMIS event(s) of type ingestion
+    And in the METS file there are/is 7 PREMIS event(s) of type message digest calculation with properties {"eventDetail": [["contains", "program=\"python\""], ["contains", "module=\"hashlib.sha256()\""]], "eventOutcomeInformation/eventOutcomeDetail/eventOutcomeDetailNote": [["regex", "^[a-f0-9]+$"]]}
+    And in the METS file there are/is 7 PREMIS event(s) of type virus check with properties {"eventDetail": [["contains",  "program=\"ClamAV"]], "eventOutcomeInformation/eventOutcome": [["equals", "Pass"]]}
 
   @package
   Scenario: Isla wants to confirm that an unpacking PREMIS event is created when a package is ingested
-  Given that the user has ensured that the default processing config is in its default state
-  And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Fido"
-  And the processing config decision "Assign UUIDs to directories" is set to "No"
-  And the processing config decision "Perform policy checks on originals" is set to "No"
-  And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
-  And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Fido"
-  And the processing config decision "Normalize" is set to "Do not normalize"
-  And the processing config decision "Approve normalization" is set to "Yes"
-  And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
-  And the processing config decision "Perform policy checks on access derivatives" is set to "No"
-  And the processing config decision "Bind PIDs" is set to "No"
-  And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Fido"
-  When a transfer is initiated on directory ~/archivematica-sampledata/TestTransfers/Unicode
-  And the user waits for the "Store AIP (review)" decision point to appear during ingest
-  Then in the METS file there are/is 11 PREMIS event(s) of type unpacking
+    Given that the user has ensured that the default processing config is in its default state
+    And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Fido"
+    And the processing config decision "Assign UUIDs to directories" is set to "No"
+    And the processing config decision "Perform policy checks on originals" is set to "No"
+    And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
+    And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Fido"
+    And the processing config decision "Normalize" is set to "Do not normalize"
+    And the processing config decision "Approve normalization" is set to "Yes"
+    And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
+    And the processing config decision "Perform policy checks on access derivatives" is set to "No"
+    And the processing config decision "Bind PIDs" is set to "No"
+    And the processing config decision "Document empty directories" is set to "No"
+    And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Fido"
+    When a transfer is initiated on directory ~/archivematica-sampledata/TestTransfers/Unicode
+    And the user waits for the "Store AIP (review)" decision point to appear during ingest
+    Then in the METS file there are/is 11 PREMIS event(s) of type unpacking
 
   @registration
   Scenario: Isla wants to confirm that a registration PREMIS event is created when an accession number is provided with a transfer
-  Given that the user has ensured that the default processing config is in its default state
-  And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Fido"
-  And the processing config decision "Assign UUIDs to directories" is set to "No"
-  And the processing config decision "Perform policy checks on originals" is set to "No"
-  And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
-  And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Fido"
-  And the processing config decision "Normalize" is set to "Do not normalize"
-  And the processing config decision "Approve normalization" is set to "Yes"
-  And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
-  And the processing config decision "Perform policy checks on access derivatives" is set to "No"
-  And the processing config decision "Bind PIDs" is set to "No"
-  And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Fido"
-  When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer with accession number 1234-567
-  And the user waits for the "Store AIP (review)" decision point to appear during ingest
-  Then in the METS file there are/is 6 PREMIS event(s) of type registration with properties {"eventOutcomeInformation/eventOutcomeDetail/eventOutcomeDetailNote": [["equals", "accession#1234-567"]]}
+    Given that the user has ensured that the default processing config is in its default state
+    And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Fido"
+    And the processing config decision "Assign UUIDs to directories" is set to "No"
+    And the processing config decision "Perform policy checks on originals" is set to "No"
+    And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
+    And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Fido"
+    And the processing config decision "Normalize" is set to "Do not normalize"
+    And the processing config decision "Approve normalization" is set to "Yes"
+    And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
+    And the processing config decision "Perform policy checks on access derivatives" is set to "No"
+    And the processing config decision "Bind PIDs" is set to "No"
+    And the processing config decision "Document empty directories" is set to "No"
+    And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Fido"
+    When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer with accession number 1234-567
+    And the user waits for the "Store AIP (review)" decision point to appear during ingest
+    Then in the METS file there are/is 6 PREMIS event(s) of type registration with properties {"eventOutcomeInformation/eventOutcomeDetail/eventOutcomeDetailNote": [["equals", "accession#1234-567"]]}
 
   @quarantine
   Scenario: Isla wants to confirm that quarantine PREMIS events are created when files are put under quarantine
-  Given that the user has ensured that the default processing config is in its default state
-  And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Fido"
-  And the processing config decision "Assign UUIDs to directories" is set to "No"
-  And the processing config decision "Perform policy checks on originals" is set to "No"
-  And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
-  And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Fido"
-  And the processing config decision "Normalize" is set to "Do not normalize"
-  And the processing config decision "Approve normalization" is set to "Yes"
-  And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
-  And the processing config decision "Perform policy checks on access derivatives" is set to "No"
-  And the processing config decision "Bind PIDs" is set to "No"
-  And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Fido"
-  And the processing config decision "Send transfer to quarantine" is set to "None"
-  When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer
-  And the user waits for the "Workflow decision - send transfer to quarantine" decision point to appear and chooses "Quarantine" during transfer
-  And the user waits for the "Remove from quarantine" decision point to appear and chooses "Unquarantine" during transfer
-  And the user waits for the "Store AIP (review)" decision point to appear during ingest
-  Then in the METS file there are/is 6 PREMIS event(s) of type quarantine
-  And in the METS file there are/is 6 PREMIS event(s) of type unquarantine
+    Given that the user has ensured that the default processing config is in its default state
+    And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Fido"
+    And the processing config decision "Assign UUIDs to directories" is set to "No"
+    And the processing config decision "Perform policy checks on originals" is set to "No"
+    And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
+    And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Fido"
+    And the processing config decision "Normalize" is set to "Do not normalize"
+    And the processing config decision "Approve normalization" is set to "Yes"
+    And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
+    And the processing config decision "Perform policy checks on access derivatives" is set to "No"
+    And the processing config decision "Bind PIDs" is set to "No"
+    And the processing config decision "Document empty directories" is set to "No"
+    And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Fido"
+    And the processing config decision "Send transfer to quarantine" is set to "None"
+    When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer
+    And the user waits for the "Workflow decision - send transfer to quarantine" decision point to appear and chooses "Quarantine" during transfer
+    And the user waits for the "Remove from quarantine" decision point to appear and chooses "Unquarantine" during transfer
+    And the user waits for the "Store AIP (review)" decision point to appear during ingest
+    Then in the METS file there are/is 6 PREMIS event(s) of type quarantine
+    And in the METS file there are/is 6 PREMIS event(s) of type unquarantine
 
   @format-identification
   Scenario: Isla wants to confirm that quarantine PREMIS events are created when files are put under quarantine
-  Given that the user has ensured that the default processing config is in its default state
-  And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Siegfried"
-  And the processing config decision "Assign UUIDs to directories" is set to "No"
-  And the processing config decision "Perform policy checks on originals" is set to "No"
-  And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
-  And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Siegfried"
-  And the processing config decision "Normalize" is set to "Do not normalize"
-  And the processing config decision "Approve normalization" is set to "Yes"
-  And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
-  And the processing config decision "Perform policy checks on access derivatives" is set to "No"
-  And the processing config decision "Bind PIDs" is set to "No"
-  And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Siegfried"
-  When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer
-  And the user waits for the "Store AIP (review)" decision point to appear during ingest
-  Then in the METS file there are/is 7 PREMIS event(s) of type format identification with properties {"eventDetail": [["contains", "program=\"Siegfried\"; version="]], "eventOutcomeInformation/eventOutcome": [["equals", "Positive"]], "eventOutcomeInformation/eventOutcomeDetail/eventOutcomeDetailNote": [["contains", "fmt"]]}
-
+    Given that the user has ensured that the default processing config is in its default state
+    And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Siegfried"
+    And the processing config decision "Assign UUIDs to directories" is set to "No"
+    And the processing config decision "Perform policy checks on originals" is set to "No"
+    And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"
+    And the processing config decision "Select file format identification command (Ingest)" is set to "Identify using Siegfried"
+    And the processing config decision "Normalize" is set to "Do not normalize"
+    And the processing config decision "Approve normalization" is set to "Yes"
+    And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"
+    And the processing config decision "Perform policy checks on access derivatives" is set to "No"
+    And the processing config decision "Bind PIDs" is set to "No"
+    And the processing config decision "Document empty directories" is set to "No"
+    And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Siegfried"
+    When a transfer is initiated on directory ~/archivematica-sampledata/SampleTransfers/BagTransfer
+    And the user waits for the "Store AIP (review)" decision point to appear during ingest
+    Then in the METS file there are/is 7 PREMIS event(s) of type format identification with properties {"eventDetail": [["contains", "program=\"Siegfried\"; version="]], "eventOutcomeInformation/eventOutcome": [["equals", "Positive"]], "eventOutcomeInformation/eventOutcomeDetail/eventOutcomeDetailNote": [["contains", "fmt"]]}

--- a/features/steps/mediaconch_steps.py
+++ b/features/steps/mediaconch_steps.py
@@ -83,6 +83,8 @@ def step_impl(context):
         'And the processing config decision "Bind PIDs" is set to "No"\n'
         'And the processing config decision "Store AIP location" is set to'
         ' "Store AIP in standard Archivematica Directory"\n'
+        'And the processing config decision "Document empty directories" is set'
+        ' to "No"\n'
         'And the processing config decision "Upload DIP" is set to'
         ' "Do not upload DIP"'
     )
@@ -255,7 +257,7 @@ def step_impl(context, policy_file):
 def step_impl(context, purpose, policy_file):
     context.am_user.browser.ensure_fpr_rule(
         purpose,
-        'Video: Matroska: Generic MKV',
+        'Video: Matroska: Generic MKV (fmt/569)',
         context.am_user.browser.get_policy_command_description(policy_file)
     )
 

--- a/features/steps/mets_steps.py
+++ b/features/steps/mets_steps.py
@@ -26,7 +26,14 @@ def step_impl(context, count, event_type, properties):
             events.append(premis_evt_el)
             utils.assert_premis_event(event_type, premis_evt_el, context)
             utils.assert_premis_properties(premis_evt_el, context, properties)
-    assert len(events) == int(count)
+    assert len(events) == int(count), (
+        'We expected to find {count} events of type {event_type} matching'
+        ' properties `{properties}` but in fact we only found'
+        ' {events_count}.'.format(
+            count=count,
+            event_type=event_type,
+            properties=str(properties),
+            events_count=len(events)))
 
 
 @then('in the METS file there are/is {count} PREMIS event(s) of type'

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -109,6 +109,8 @@ def step_impl(context):
         ' derivatives" is set to "No"\n'
         'And the processing config decision "Perform policy checks on'
         ' originals" is set to "No"\n'
+        'And the processing config decision "Document empty directories"'
+        ' is set to "No"\n'
     )
 
 

--- a/features/steps/uuids_for_directories_steps.py
+++ b/features/steps/uuids_for_directories_steps.py
@@ -129,6 +129,15 @@ def step_impl(context):
         ' set to "Yes"\n')
 
 
+@given('default processing configured to assign UUIDs to all directories')
+def step_impl(context):
+    context.execute_steps(
+        'Given the processing config decision "Assign UUIDs to directories" is'
+        ' set to "Yes"\n'
+        'And the processing config decision "Document empty directories" is'
+        ' set to "Yes"\n')
+
+
 # Thens
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Accounts for the new "Document empty directories" decision point.

- Modifies the tests/features to account for the new "Document empty directories" decision point.
- Acconts for PRONOM IDs in GUI when selecting formats, e.g., "Video: Matroska: Generic MKV (fmt/569)".
- Comments out a line so that the ingest-mkv-conformance feature no longer runs a transfer on preforma/when-normalized-none-valid; this change was made because the .mp4 file in that transfer source no longer produces an .mkv file that MediaConch thinks is invalid (since the upgrade to MC 18.03).

Fixes #79