### PR TITLE
Fix performance-stdout-no-write feature

### DIFF
--- a/features/core/performance-stdout-no-write.feature
+++ b/features/core/performance-stdout-no-write.feature
@@ -28,9 +28,8 @@
 #         -D driver_name=Firefox \
 #         -D am_url=http://127.0.0.1:62080/ \
 #         -D am_password=test \
-#         -D home="" \
 #         -D am_version=1.7 \
-#         -D docker_compose_path=/abs/path/to/am/compose
+#         -D docker_compose_path=/abs/path/to/am/compose \
 #         -D home=archivematica
 
 # Results

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -121,6 +121,8 @@ def step_impl(context):
         'Given the default processing config is in its default state\n'
         'And the processing config decision "Assign UUIDs to directories" is'
         ' set to "No"\n'
+        'And the processing config decision "Document empty directories" is'
+        ' set to "No"\n'
         'And the processing config decision "Select file format identification'
         ' command (Transfer)" is set to "Identify using Siegfried"\n'
         'And the processing config decision "Perform policy checks on'


### PR DESCRIPTION
Modifies a step of the performance-stdout-no-write.feature so that it makes a processing config decision for the "Document empty directories" choice point. Also fixes a minor issue with the example behave command provided.

Fixes #89