### PR TITLE
Add infinite AIPs feature

### DIFF
--- a/features/core/infinite-aips.feature
+++ b/features/core/infinite-aips.feature
@@ -1,0 +1,30 @@
+# Infinite AIPs Feature File
+# ==============================================================================
+
+# Example behave command to run this feature::
+#
+#     $ behave \
+#           --tags=infinite-aips \
+#           --no-skipped \
+#           --no-logcapture \
+#           -D runtime_supplied_transfer_path='~/archivematica-sampledata/TestTransfers/small' \
+#           -D driver_name=Firefox \
+#           -D am_url=http://127.0.0.1:62080/ \
+#           -D am_password=test \
+#           -D am_version=1.7 \
+#           -D home=archivematica
+#
+
+@infinite-aips
+Feature: Infinite AIPs
+  Archivematica's developers want to automate the process of creating (large) AIPs
+  until something breaks. This feature will help the developers to add features
+  that make Archivematica more resilient when system resource and service
+  limits are reached.
+
+  Scenario: Joel creates an AIP from a runtime-supplied transfer source path repeatedly until something goes wrong.
+    Given a default processing config that creates and stores an AIP
+    When a transfer is initiated on the runtime-supplied directory
+    And the user waits for the AIP to appear in archival storage
+    # The following is a recursive step that calls the above two and then itself
+    And the user creates the same AIP all over again

--- a/features/environment.py
+++ b/features/environment.py
@@ -82,6 +82,8 @@ def get_am_user(userdata):
         'server_password': userdata.get('server_password', SERVER_PASSWORD),
         'ssh_identity_file': userdata.get(
             'ssh_identity_file', SSH_IDENTITY_FILE),
+        'runtime_supplied_transfer_path': userdata.get(
+            'runtime_supplied_transfer_path'),
         # User-customizable wait values:
         'nihilistic_wait': userdata.get('nihilistic_wait', NIHILISTIC_WAIT),
         'apathetic_wait': userdata.get('apathetic_wait', APATHETIC_WAIT),

--- a/features/steps/infinite_aips.py
+++ b/features/steps/infinite_aips.py
@@ -1,0 +1,39 @@
+"""Infinite AIPs Steps."""
+
+import logging
+
+from behave import when
+
+from features.steps import utils
+
+
+logger = logging.getLogger('amauat.steps.infiniteaips')
+
+
+# Givens
+# ------------------------------------------------------------------------------
+
+
+# Whens
+# ------------------------------------------------------------------------------
+
+@when('a transfer is initiated on the runtime-supplied directory')
+def step_impl(context):
+    transfer_path = context.am_user.runtime_supplied_transfer_path
+    utils.initiate_transfer(context, transfer_path)
+
+
+@when('the user creates the same AIP all over again')
+def step_impl(context):
+    # This is necessary so that we don't incorrectly use the
+    # ``context.scenario.sip_uuid`` value set on previous iterations.
+    context.scenario.sip_uuid = None
+    context.execute_steps(
+        'When a transfer is initiated on the runtime-supplied directory\n'
+        'And the user waits for the AIP to appear in archival storage\n'
+        'And the user creates the same AIP all over again\n'  # <= recursive
+    )
+
+
+# Thens
+# ------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #112. To run:

    $ behave \
          --tags=infinite-aips \
          --no-skipped \
          --no-logcapture \
          -D runtime_supplied_transfer_path='~/archivematica-sampledata/TestTransfers/small' \
          -D driver_name=Firefox \
          -D am_url=http://127.0.0.1:62080/ \
          -D am_password=test \
          -D am_version=1.7 \
          -D home=archivematica

TODO:

- test on large transfers; expect timeouts to be reached and provide guidelines for tweaking timeout values at runtime.