### PR TITLE
Compare branch feature

### DIFF
--- a/amuser/am_browser_ingest_ability.py
+++ b/amuser/am_browser_ingest_ability.py
@@ -61,6 +61,11 @@ class ArchivematicaBrowserIngestAbility(
         sip_uuid, _, _ = (
             self.wait_for_transfer_to_appear(transfer_name))
         logger.info('Got SIP UUID %s', sip_uuid)
+
+        if sip_uuid is None:
+            logger.error("Can't continue without a SIP UUID")
+            raise
+
         return sip_uuid
 
     def get_mets(self, transfer_name, sip_uuid=None, parse_xml=True):

--- a/amuser/am_browser_transfer_ability.py
+++ b/amuser/am_browser_transfer_ability.py
@@ -126,49 +126,47 @@ class ArchivematicaBrowserTransferAbility(
         """
         transfer_name_div_selector = 'div.sip-detail-directory'
         transfer_uuid_div_selector = 'div.sip-detail-uuid'
-        self.wait_for_presence(transfer_name_div_selector)
-        transfer_uuid = correct_transfer_div_elem = None
-        for transfer_div_elem in self.driver\
-                .find_elements_by_css_selector(c.SELECTOR_TRANSFER_DIV):
-            transfer_name_div_elem = transfer_div_elem\
-                .find_element_by_css_selector(transfer_name_div_selector)
-            transfer_uuid_div_elem = transfer_div_elem\
-                .find_element_by_css_selector(transfer_uuid_div_selector)
-            # Identify the transfer by its name. The complication here is that
-            # AM detects a narrow browser window and hides the UUID in the
-            # narrow case. So depending on the visibility/width of things, we
-            # find the UUID in different places.
-            transfer_name_in_dom = transfer_name_div_elem.text.strip()
-            if transfer_name_in_dom.endswith('UUID'):
-                transfer_name_in_dom = transfer_name_in_dom[:-4].strip()
-            if name_is_prefix:
-                cond = transfer_name_in_dom.startswith(transfer_name)
-            else:
-                cond = transfer_name_in_dom == transfer_name
-            if cond:
-                logger.info('Changed transfer name from %s to %s',
-                            transfer_name, transfer_name_in_dom)
-                transfer_name = transfer_name_in_dom
-                abbr_elem = transfer_name_div_elem.find_element_by_tag_name(
-                    'abbr')
-                if abbr_elem and abbr_elem.is_displayed():
-                    transfer_uuid = abbr_elem.get_attribute('title').strip()
+        for attempt in range(self.max_check_transfer_appeared_attempts):
+            self.wait_for_presence(transfer_name_div_selector)
+            transfer_uuid = correct_transfer_div_elem = None
+            for transfer_div_elem in self.driver\
+                    .find_elements_by_css_selector(c.SELECTOR_TRANSFER_DIV):
+                transfer_name_div_elem = transfer_div_elem\
+                    .find_element_by_css_selector(transfer_name_div_selector)
+                transfer_uuid_div_elem = transfer_div_elem\
+                    .find_element_by_css_selector(transfer_uuid_div_selector)
+                # Identify the transfer by its name. The complication here is that
+                # AM detects a narrow browser window and hides the UUID in the
+                # narrow case. So depending on the visibility/width of things, we
+                # find the UUID in different places.
+                transfer_name_in_dom = transfer_name_div_elem.text.strip()
+                if transfer_name_in_dom.endswith('UUID'):
+                    transfer_name_in_dom = transfer_name_in_dom[:-4].strip()
+                if name_is_prefix:
+                    cond = transfer_name_in_dom.startswith(transfer_name)
                 else:
-                    transfer_uuid = transfer_uuid_div_elem.text.strip()
-                correct_transfer_div_elem = transfer_div_elem
-        if not transfer_uuid:
-            self.check_transfer_appeared_attempts += 1
-            if (self.check_transfer_appeared_attempts <
-                    self.max_check_transfer_appeared_attempts):
-                time.sleep(self.quick_wait)
-                transfer_uuid, correct_transfer_div_elem, transfer_name = (
-                    self.wait_for_transfer_to_appear(
-                        transfer_name, name_is_prefix=name_is_prefix))
+                    cond = transfer_name_in_dom == transfer_name
+                if cond:
+                    logger.info('Changed transfer name from %s to %s',
+                                transfer_name, transfer_name_in_dom)
+                    transfer_name = transfer_name_in_dom
+                    abbr_elem = transfer_name_div_elem.find_element_by_tag_name(
+                        'abbr')
+                    if abbr_elem and abbr_elem.is_displayed():
+                        transfer_uuid = abbr_elem.get_attribute('title').strip()
+                    else:
+                        transfer_uuid = transfer_uuid_div_elem.text.strip()
+                    correct_transfer_div_elem = transfer_div_elem
+            time.sleep(self.quick_wait)
+            if transfer_uuid:
+                return transfer_uuid, correct_transfer_div_elem, transfer_name
             else:
-                self.check_transfer_appeared_attempts = 0
-                return None, None, None
-        time.sleep(self.quick_wait)
-        return transfer_uuid, correct_transfer_div_elem, transfer_name
+                # retry
+                pass
+
+        logger.info("Giving up waiting for transfer after %d attempts",
+                    self.check_transfer_appeared_attempts)
+        return None, None, None
 
     def click_start_transfer_button(self):
         start_transfer_button_elem = self.driver.find_element_by_css_selector(

--- a/amuser/am_docker_ability.py
+++ b/amuser/am_docker_ability.py
@@ -25,6 +25,13 @@ class ArchivematicaDockerAbility(base.Base):
     def docker_compose_file_path(self):
         return os.path.join(self.docker_compose_path, 'docker-compose.yml')
 
+    def stop_archivematica(self):
+        """Stop Archivematica by calling docker-compose's ``down`` subcommand.
+        """
+        dc_down_cmd = 'docker-compose -f {} down'.format(self.docker_compose_file_path)
+        subprocess.run(shlex.split(dc_down_cmd))
+
+
     def recreate_archivematica(self, capture_output=False):
         """Recreate the docker-compose deploy of Archivematica by calling
         docker-compose's ``up`` subcommand.

--- a/features/core/performance-compare-branches.feature
+++ b/features/core/performance-compare-branches.feature
@@ -1,0 +1,83 @@
+# Compare Branches Feature File
+# =============================
+
+# Warning: this feature file should only be run in development. It requires a
+# docker-compose-based Archivematica deploy. The test itself must be able to
+# alter the deployment by changing an environment variable and recreating a
+# docker container.
+#
+# To run the test, deploy Archivematica locally using
+# https://github.com/artefactual-labs/am::
+#
+#     $ git clone https://github.com/artefactual-labs/am
+#     $ cd am/compose
+#     $ git submodule update --init --recursive
+#     $ make create-volumes
+#     $ docker-compose up -d --build
+#     $ make bootstrap
+#     $ make restart-am-services
+#
+# Then run the following ``behave`` command, after replacing the
+# ``docker_compose_path`` userdata option with the appropriate value for your
+# development system::
+#
+# behave \
+#         --tags=performance-compare-branches \
+#         --tags=transfer.name.size-11M-files-10 \
+#         --no-skipped \
+#         --no-logcapture \
+#         -D driver_name=Firefox \
+#         -D am_url=http://127.0.0.1:62080/ \
+#         -D am_password=test \
+#         -D am_version=1.7 \
+#         -D docker_compose_path=/abs/path/to/am/compose \
+#         -D home=archivematica \
+#         -D version_a=archivematica:branch-a \
+#         -D version_b=archivematica:branch-b \
+#         -D max_check_transfer_appeared_attempts=7200
+#
+
+# The ``version_a`` and ``version_b`` flags control which source
+# versions will be checked out for each run.  You can specify more
+# than one project here by separating them with commas.  For example:
+#
+#     -D version_a=archivematica:somebranch,archivematica-storage-service:anotherbranch
+#
+# Will set things running with particular versions for archivematica
+# and the storage service.
+#
+#
+# Note the flag ``--tags=transfer.name.size-11M-files-10`` in the above
+# command. This tells behave to only run the scenario on the row of the
+# ``Examples`` table with name ``size-11M-files-10``. Omit this flag to run all
+# example rows or change it to another to run a different row.
+
+@performance-compare-branches @developer
+Feature: Compare ingest/transfer performance across branches
+  Archivematica's developers want to test whether one branch completes
+  ingests/transfer more quickly than another
+
+  @transfer.name.<name>
+  Scenario Outline: Two branches enter.  One branch leaves.
+    Given an Archivematica instance running version_a
+    And the default processing config is set to automate a transfer through to "Store AIP"
+
+    When a transfer is initiated on directory <transfer_source>
+    And the user waits for the "Store AIP (review)" decision point to appear during ingest
+    And performance statistics are saved to version_a_stats
+
+    when the user alters the Archivematica instance to run version_b
+
+    When a transfer is initiated on directory <transfer_source>
+    And the user waits for the "Store AIP (review)" decision point to appear during ingest
+    And performance statistics are saved to version_b_stats
+
+    And the difference in runtime between version_a_stats and version_b_stats is printed
+
+    Examples: Archivematica transfer sources
+    | name                | transfer_source                                                                       |
+    | size-4K-files-1     | ~/archivematica-sampledata/TestTransfers/small                                        |
+    | size-11M-files-10   | ~/archivematica-sampledata/SampleTransfers/Images                                     |
+    | size-1.9G-files-113 | ~/archivematica-sampledata/TestTransfers/acceptance-tests/performance/images-17M-each |
+    | size-11G-files-669  | ~/archivematica-sampledata/TestTransfers/acceptance-tests/performance/video-14M-each  |
+

--- a/features/environment.py
+++ b/features/environment.py
@@ -94,35 +94,35 @@ def get_am_user(userdata):
         'micro_wait': userdata.get('micro_wait', MICRO_WAIT),
         # User-customizable max attempt values:
         'max_click_transfer_directory_attempts':
-            userdata.get('max_click_transfer_directory_attempts',
-                         MAX_CLICK_TRANSFER_DIRECTORY_ATTEMPTS),
+            int(userdata.get('max_click_transfer_directory_attempts',
+                             MAX_CLICK_TRANSFER_DIRECTORY_ATTEMPTS)),
         'max_click_aip_directory_attempts':
-            userdata.get('max_click_aip_directory_attempts',
-                         MAX_CLICK_AIP_DIRECTORY_ATTEMPTS),
+            int(userdata.get('max_click_aip_directory_attempts',
+                             MAX_CLICK_AIP_DIRECTORY_ATTEMPTS)),
         'max_navigate_aip_archival_storage_attempts':
-            userdata.get('max_navigate_aip_archival_storage_attempts',
-                         MAX_NAVIGATE_AIP_ARCHIVAL_STORAGE_ATTEMPTS),
+            int(userdata.get('max_navigate_aip_archival_storage_attempts',
+                             MAX_NAVIGATE_AIP_ARCHIVAL_STORAGE_ATTEMPTS)),
         'max_download_aip_attempts':
-            userdata.get('max_download_aip_attempts',
-                         MAX_DOWNLOAD_AIP_ATTEMPTS),
+            int(userdata.get('max_download_aip_attempts',
+                             MAX_DOWNLOAD_AIP_ATTEMPTS)),
         'max_check_aip_stored_attempts':
-            userdata.get('max_check_aip_stored_attempts',
-                         MAX_CHECK_AIP_STORED_ATTEMPTS),
+            int(userdata.get('max_check_aip_stored_attempts',
+                             MAX_CHECK_AIP_STORED_ATTEMPTS)),
         'max_check_mets_loaded_attempts':
-            userdata.get('max_check_mets_loaded_attempts',
-                         MAX_CHECK_METS_LOADED_ATTEMPTS),
+            int(userdata.get('max_check_mets_loaded_attempts',
+                             MAX_CHECK_METS_LOADED_ATTEMPTS)),
         'max_search_aip_archival_storage_attempts':
-            userdata.get('max_search_aip_archival_storage_attempts',
-                         MAX_SEARCH_AIP_ARCHIVAL_STORAGE_ATTEMPTS),
+            int(userdata.get('max_search_aip_archival_storage_attempts',
+                             MAX_SEARCH_AIP_ARCHIVAL_STORAGE_ATTEMPTS)),
         'max_search_dip_backlog_attempts':
-            userdata.get('max_search_dip_backlog_attempts',
-                         MAX_SEARCH_DIP_BACKLOG_ATTEMPTS),
+            int(userdata.get('max_search_dip_backlog_attempts',
+                             MAX_SEARCH_DIP_BACKLOG_ATTEMPTS)),
         'max_check_transfer_appeared_attempts':
-            userdata.get('max_check_transfer_appeared_attempts',
-                         MAX_CHECK_TRANSFER_APPEARED_ATTEMPTS),
+            int(userdata.get('max_check_transfer_appeared_attempts',
+                             MAX_CHECK_TRANSFER_APPEARED_ATTEMPTS)),
         'max_check_for_ms_group_attempts':
-            userdata.get('max_check_for_ms_group_attempts',
-                         MAX_CHECK_FOR_MS_GROUP_ATTEMPTS)
+            int(userdata.get('max_check_for_ms_group_attempts',
+                             MAX_CHECK_FOR_MS_GROUP_ATTEMPTS))
     })
     return amuser.ArchivematicaUser(**userdata)
 

--- a/features/steps/performance_compare_branches_steps.py
+++ b/features/steps/performance_compare_branches_steps.py
@@ -1,0 +1,71 @@
+import logging
+import json
+import os
+import re
+import subprocess
+import time
+
+from behave import when, then, given
+from features.steps import utils
+
+logger = logging.getLogger('amauat.steps.performancenocapture')
+
+
+def switch_to_version(context, version):
+    context.scenario.transfer_uuid = None
+    context.scenario.transfer_name = None
+    context.scenario.sip_uuid = None
+
+    docker_compose_path = getattr(context.am_user.docker, 'docker_compose_path', None)
+    version = getattr(context.am_user.docker, version, None)
+
+    if docker_compose_path is None:
+        raise Exception("docker_compose_path parameter must be provided")
+
+    if version is None:
+        raise Exception(version + " parameter must be provided")
+
+    package_versions = [re.split(" *: *", package) for package in re.split(" *, *", version)]
+
+    for (package, version) in package_versions:
+        package_dir = os.path.join(docker_compose_path, "..", "src", package)
+
+        logger.info("Hard resetting '%s' to version %s" % (package_dir, version))
+
+        subprocess.run(["git", "reset", "--hard", version],
+                       cwd=package_dir)
+
+    context.am_user.docker.stop_archivematica()
+    context.am_user.docker.recreate_archivematica()
+
+@given(u'an Archivematica instance running version_a')
+def step_impl(context):
+    switch_to_version(context, 'version_a')
+
+@when(u'the user alters the Archivematica instance to run version_b')
+def step_impl(context):
+    switch_to_version(context, 'version_b')
+
+def add_duration_float(tasks):
+    for task in tasks:
+        task['duration_float'] = utils.get_duration_as_float(task['duration'])
+    return tasks
+
+@when('the difference in runtime between {version_a_fname} and {version_b_fname} is printed')
+def step_impl(context, version_a_fname, version_b_fname):
+    version_a_stats = utils.get_stats_file_json(version_a_fname, context.am_user.permanent_path)
+    version_b_stats = utils.get_stats_file_json(version_b_fname, context.am_user.permanent_path)
+
+    logger.info('Total runtime for version_a tasks: %f; Total runtime for version_b tasks: %f',
+                tasks_duration_seconds(version_a_stats['tasks']),
+                tasks_duration_seconds(version_b_stats['tasks']))
+
+# Helpers
+# ------------------------------------------------------------------------------
+
+def tasks_duration_seconds(tasks):
+    timefmt = '%Y-%m-%d %H:%M:%S.%f'
+    earliest = min([time.strptime(task['startTime'], timefmt) for task in tasks])
+    latest = max([time.strptime(task['endTime'], timefmt) for task in tasks])
+
+    return time.mktime(latest) - time.mktime(earliest)

--- a/features/steps/performance_stdout_no_write_steps.py
+++ b/features/steps/performance_stdout_no_write_steps.py
@@ -70,9 +70,9 @@ def step_impl(context, filename):
 @then('the size of the {without_outputs_fname} METS file is less than that of'
       ' the {with_outputs_fname} METS file')
 def step_impl(context, without_outputs_fname, with_outputs_fname):
-    without_outputs_stats = get_stats_file_json(
+    without_outputs_stats = utils.get_stats_file_json(
         without_outputs_fname, context.am_user.permanent_path)
-    with_outputs_stats = get_stats_file_json(
+    with_outputs_stats = utils.get_stats_file_json(
         with_outputs_fname, context.am_user.permanent_path)
     without_outputs_mets = without_outputs_stats['mets']
     with_outputs_mets = with_outputs_stats['mets']
@@ -88,9 +88,9 @@ def step_impl(context, without_outputs_fname, with_outputs_fname):
 @then('the runtime of client scripts in {without_outputs_fname} is less'
       ' than the runtime of client scripts in {with_outputs_fname}')
 def step_impl(context, without_outputs_fname, with_outputs_fname):
-    without_outputs_stats = get_stats_file_json(
+    without_outputs_stats = utils.get_stats_file_json(
         without_outputs_fname, context.am_user.permanent_path)
-    with_outputs_stats = get_stats_file_json(
+    with_outputs_stats = utils.get_stats_file_json(
         with_outputs_fname, context.am_user.permanent_path)
     without_outputs_tasks = without_outputs_stats['tasks']
     with_outputs_tasks = with_outputs_stats['tasks']
@@ -141,15 +141,3 @@ def add_duration_float(tasks):
     for task in tasks:
         task['duration_float'] = utils.get_duration_as_float(task['duration'])
     return tasks
-
-
-def get_newest_file_with_prefix(dirpath, filename_prefix):
-    files = [f for f in os.listdir(dirpath) if f.startswith(filename_prefix)]
-    return os.path.join(dirpath, sorted(files)[-1])
-
-
-def get_stats_file_json(fname, permanent_path):
-    fpath = get_newest_file_with_prefix(permanent_path, fname)
-    logger.info('file path for %s is %s', fname, fpath)
-    with open(fpath) as fi:
-        return json.load(fi)

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import zipfile
+import json
 
 
 logger = logging.getLogger('amauat.steps.utils')
@@ -252,3 +253,15 @@ def unzip(zip_path):
     if os.path.isdir(directory_to_extract_to):
         return directory_to_extract_to
     return None
+
+
+def get_newest_file_with_prefix(dirpath, filename_prefix):
+    files = [f for f in os.listdir(dirpath) if f.startswith(filename_prefix)]
+    return os.path.join(dirpath, sorted(files)[-1])
+
+
+def get_stats_file_json(fname, permanent_path):
+    fpath = get_newest_file_with_prefix(permanent_path, fname)
+    logger.info('file path for %s is %s', fname, fpath)
+    with open(fpath) as fi:
+        return json.load(fi)


### PR DESCRIPTION

This one isn't intended to be merged right away--just sending a PR so we have something to discuss during our call next week.

-------
This PR adds a new acceptance test that automates the process of running a given transfer/ingest with two different versions of the AM codebase, reporting the difference in duration and recording some statistics.  It's based on Joel's `performance-stdout-no-write.feature`.

I've been using this to test the MCP batching changes and I'm seeing the same sort of performance increases as I saw in my previous manual testing.