### PR TITLE
Fixes PID-binding tests in AMAUAT

### DIFF
--- a/amuser/am_browser_ingest_ability.py
+++ b/amuser/am_browser_ingest_ability.py
@@ -77,7 +77,7 @@ class ArchivematicaBrowserIngestAbility(
         # Wait for the "Store AIP" micro-service.
         ms_name = utils.normalize_ms_name('Store AIP (review)', self.vn)
         self.expose_job(ms_name, sip_uuid, 'ingest')
-        aip_preview_url = '{}/ingest/preview/aip/{}'.format(
+        aip_preview_url = self.get_aip_preview_url(sip_uuid).format(
             self.am_url, sip_uuid)
         self.navigate(aip_preview_url)
         mets_path = 'storeAIP/{}-{}/METS.{}.xml'.format(
@@ -180,7 +180,8 @@ class ArchivematicaBrowserIngestAbility(
         if self.driver.current_url != url:
             self.login()
         self.driver.get(url)
-        ms_name = utils.normalize_ms_name('Approve normalization (review)', self.vn)
+        ms_name = utils.normalize_ms_name(
+            'Approve normalization (review)', self.vn)
         self.expose_job(ms_name, sip_uuid, 'sip')
         nrmlztn_rprt_url = self.get_normalization_report_url(sip_uuid)
         self.driver.get(nrmlztn_rprt_url)

--- a/amuser/am_browser_transfer_ability.py
+++ b/amuser/am_browser_transfer_ability.py
@@ -42,8 +42,8 @@ class ArchivematicaBrowserTransferAbility(
         if transfer_type:
             self.set_transfer_type(transfer_type)
             # For some reason selecting a transfer type can cause the window to
-            # scroll and will prevent Selenium from clicking the "Browse" button
-            # so the following line is necessary.
+            # scroll and will prevent Selenium from clicking the "Browse"
+            # button so the following line is necessary.
             self.driver.execute_script('window.scrollTo(0, 0);')
             if transfer_type == 'Zipped bag':
                 name_is_prefix = True
@@ -57,18 +57,22 @@ class ArchivematicaBrowserTransferAbility(
             self.enter_accession_no(accession_no)
         self.add_transfer_directory(transfer_path)
         self.click_start_transfer_button()
+
         transfer_uuid, transfer_div_elem, transfer_name = (
             self.wait_for_transfer_to_appear(
                 transfer_name, name_is_prefix=name_is_prefix))
-        # UUID for the "Approve transfer" option
-        approve_option_uuid = {
-            'Standard': c.APPROVE_STANDARD_TRANSFER_UUID,
-            'Zipped bag': c.APPROVE_ZIPPED_BAGIT_TRANSFER_UUID,
-            'Unzipped bag': c.APPROVE_BAGIT_TRANSFER_UUID,
-            'DSpace': c.APPROVE_DSPACE_TRANSFER_UUID
-        }[transfer_type]
-        self.approve_transfer(transfer_div_elem, approve_option_uuid,
-                              transfer_name, name_is_prefix)
+
+        # In Archivematica 1.8 transfers can be automatically approved. This
+        # is the default in the system. Use the ``am_version`` flag to make
+        # sure that approval is not a required step for tests >= 1.8.
+        if self.vn < '1.8':
+            # UUID for the "Approve transfer" option
+            approve_option_uuid = {
+                'Standard': c.APPROVE_STANDARD_TRANSFER_UUID,
+                'Zipped bag': c.APPROVE_ZIPPED_BAGIT_TRANSFER_UUID,
+            }[transfer_type]
+            self.approve_transfer(transfer_div_elem, approve_option_uuid,
+                                  transfer_name, name_is_prefix)
         return transfer_uuid, transfer_name
 
     def remove_all_transfers(self):
@@ -120,8 +124,8 @@ class ArchivematicaBrowserTransferAbility(
         """Wait until the transfer appears in the transfer tab (after "Start
         transfer" has been clicked). The only way to do this seems to be to
         check each row for our unique ``transfer_name`` and do
-        ``time.sleep(self.micro_wait)`` until it appears, or a max number of waits is
-        exceeded.
+        ``time.sleep(self.micro_wait)`` until it appears, or a max number of
+        waits is exceeded.
         Returns the transfer UUID and the transfer <div> element.
         """
         transfer_name_div_selector = 'div.sip-detail-directory'

--- a/amuser/constants.py
+++ b/amuser/constants.py
@@ -61,12 +61,6 @@ XPATH_TREEITEM_NEXT_SIBLING = '/following-sibling::treeitem/ul/li/'
 APPROVE_STANDARD_TRANSFER_UUID = '6953950b-c101-4f4c-a0c3-0cd0684afe5e'
 APPROVE_ZIPPED_BAGIT_TRANSFER_UUID = '167dc382-4ab1-4051-8e22-e7f1c1bf3e6f'
 
-# Note: the UUIDs below are incorrect...
-APPROVE_BAGIT_TRANSFER_UUID = 'df1c53e4-1b69-441e-bdc9-6d08c3b47c9b'
-APPROVE_MAILDIR_TRANSFER_UUID = 'acf7bd62-1587-4bff-b640-5b34b7196386'
-APPROVE_DSPACE_TRANSFER_UUID = 'fa3e0099-b891-43f6-a4bc-390d544fa3e9'
-APPROVE_TRIM_TRANSFER_UUID = '07bf7432-fd9b-456e-9d17-5b387087723a'
-
 
 def varvn(varname, vn):
     """Return global var/constant named ``varname`` for version ``vn``, if it
@@ -85,38 +79,48 @@ def varvn(varname, vn):
 # A map from each micro-service name (i.e., description) to the tuple of
 # micro-service groups that it belongs to.
 MICRO_SERVICES2GROUPS = {
-    'Add processed structMap to METS.xml document': ('Update METS.xml document',),
+    'Add processed structMap to METS.xml document':
+        ('Update METS.xml document',),
     'Approve AIP reingest': ('Reingest AIP',),
     'Approve normalization': ('Normalize',),
     'Approve normalization (review)': ('Normalize',),
     'Approve normalization Review': ('Normalize',),
     'Approve standard transfer': ('Approve transfer',),
-    'Assign checksums and file sizes to metadata': ('Process metadata directory',),
-    'Assign checksums and file sizes to objects': ('Assign file UUIDs and checksums',),
+    'Assign checksums and file sizes to metadata':
+        ('Process metadata directory',),
+    'Assign checksums and file sizes to objects':
+        ('Assign file UUIDs and checksums',),
     'Assign checksums and file sizes to submissionDocumentation': (
         'Process submission documentation',),
     'Assign file UUIDs to metadata': ('Process metadata directory',),
     'Assign file UUIDs to objects': ('Assign file UUIDs and checksums',),
-    'Assign file UUIDs to submission documentation': ('Process submission documentation',),
+    'Assign file UUIDs to submission documentation':
+        ('Process submission documentation',),
     'Assign UUIDs to directories?': ('Assign file UUIDs and checksums',),
     'Attempt restructure for compliance': ('Verify transfer compliance',),
     'Bind PIDs?': ('Bind PIDs',),
-    'Characterize and extract metadata': ('Characterize and extract metadata',),
-    'Characterize and extract metadata on metadata files': ('Process metadata directory',),
+    'Characterize and extract metadata':
+        ('Characterize and extract metadata',),
+    'Characterize and extract metadata on metadata files':
+        ('Process metadata directory',),
     'Characterize and extract metadata on submission documentation': (
         'Process submission documentation',),
     'Check for Access directory': ('Normalize',),
     'Check for Service directory': ('Normalize',),
-    'Check for manual normalized files': ('Process manually normalized files',),
+    'Check for manual normalized files':
+        ('Process manually normalized files',),
     'Check for specialized processing': ('Examine contents',),
-    'Check for submission documentation': ('Process submission documentation',),
+    'Check for submission documentation':
+        ('Process submission documentation',),
     'Check if AIP is a file or directory': ('Prepare AIP',),
     'Check if DIP should be generated': ('Prepare AIP',),
-    'Check if SIP is from Maildir Transfer': ('Rename SIP directory with SIP UUID',),
+    'Check if SIP is from Maildir Transfer':
+        ('Rename SIP directory with SIP UUID',),
     'Check transfer directory for objects': ('Create SIP from Transfer',),
     'Compress AIP': ('Prepare AIP',),
     'Copy submission documentation': ('Prepare AIP',),
-    'Copy transfer submission documentation': ('Process submission documentation',),
+    'Copy transfer submission documentation':
+        ('Process submission documentation',),
     'Copy transfers metadata and logs': ('Process metadata directory',),
     'Create AIP Pointer File': ('Prepare AIP',),
     'Create SIP from transfer objects': ('Create SIP from Transfer',),
@@ -129,8 +133,10 @@ MICRO_SERVICES2GROUPS = {
     'Document empty directories?': ('Generate AIP METS',),
     'Examine contents?': ('Examine contents',),
     'Find type to process as': ('Quarantine',),
-    'Generate METS.xml document': ('Generate METS.xml document', 'Generate AIP METS'),
-    'Generate transfer structure report': ('Generate transfer structure report',),
+    'Generate METS.xml document':
+        ('Generate METS.xml document', 'Generate AIP METS'),
+    'Generate transfer structure report':
+        ('Generate transfer structure report',),
     'Grant normalization options for no pre-existing DIP': ('Normalize',),
     'Identify file format': (
         'Identify file format',
@@ -172,12 +178,15 @@ MICRO_SERVICES2GROUPS = {
     'Normalize': ('Normalize',),
     'Normalize for preservation': ('Normalize',),
     'Normalize for thumbnails': ('Normalize',),
-    'Perform policy checks on access derivatives?': ('Policy checks for derivatives',),
+    'Perform policy checks on access derivatives?':
+        ('Policy checks for derivatives',),
     'Perform policy checks on originals?': ('Validation',),
-    'Perform policy checks on preservation derivatives?': ('Policy checks for derivatives',),
+    'Perform policy checks on preservation derivatives?':
+        ('Policy checks for derivatives',),
     'Policy checks for access derivatives': ('Policy checks for derivatives',),
     'Policy checks for originals': ('Validation',),
-    'Policy checks for preservation derivatives': ('Policy checks for derivatives',),
+    'Policy checks for preservation derivatives':
+        ('Policy checks for derivatives',),
     'Prepare AIP': ('Prepare AIP',),
     'Process JSON metadata': ('Process metadata directory',),
     'Process transfer JSON metadata': ('Reformat metadata files',),
@@ -185,7 +194,8 @@ MICRO_SERVICES2GROUPS = {
         'Process manually normalized files',),
     'Reminder: add metadata if desired': ('Add final metadata',),
     'Remove cache files': ('Remove cache files',),
-    'Remove empty manual normalization directories': ('Process metadata directory',),
+    'Remove empty manual normalization directories':
+        ('Process metadata directory',),
     'Remove files without linking information (failed normalization'
     ' artifacts etc.)': ('Process submission documentation', 'Normalize'),
     'Remove from quarantine': ('Quarantine',),
@@ -193,13 +203,16 @@ MICRO_SERVICES2GROUPS = {
     'Remove the processing directory': ('Store AIP',),
     'Remove unneeded files': ('Verify transfer compliance',),
     'Removed bagged files': ('Prepare AIP',),
-    'Rename SIP directory with SIP UUID': ('Rename SIP directory with SIP UUID',),
+    'Rename SIP directory with SIP UUID':
+        ('Rename SIP directory with SIP UUID',),
     'Rename with transfer UUID': ('Rename with transfer UUID',),
-    'Resume after normalization file identification tool selected.': ('Normalize',),
+    'Resume after normalization file identification tool selected.':
+        ('Normalize',),
     'Retrieve AIP Storage Locations': ('Store AIP',),
     'Sanitize SIP name': ('Clean up names',),
     'Sanitize Transfer name': ('Clean up names',),
-    'Sanitize file and directory names in metadata': ('Process metadata directory',),
+    'Sanitize file and directory names in metadata':
+        ('Process metadata directory',),
     'Sanitize file and directory names in submission documentation': (
         'Process submission documentation',),
     "Sanitize object's file and directory names": ('Clean up names',),
@@ -222,7 +235,8 @@ MICRO_SERVICES2GROUPS = {
         'Verify transfer compliance',
         'Verify SIP compliance',
         'Prepare AIP'),
-    'Set remove preservation and access normalized files to renormalize link.': ('Normalize',),
+    'Set remove preservation and access normalized files to renormalize link.':
+        ('Normalize',),
     'Set transfer type: Standard': ('Verify transfer compliance',),
     'Store AIP': ('Store AIP',),
     'Store AIP (review)': ('Store AIP',),
@@ -309,7 +323,8 @@ PC_DECISION2ID = {
         'id_eeb23509-57e2-4529-8857-9d62525db048',
     'Transcribe files (OCR)':
         'id_7079be6d-3a25-41e6-a481-cee5f352fe6e',
-    'Select file format identification command (Submission documentation & metadata)':
+    'Select file format identification command '
+    '(Submission documentation & metadata)':
         'id_087d27be-c719-47d8-9bbb-9a7d8b609c44',
     'Select compression algorithm':
         'id_01d64f58-8295-4b7b-9cab-8f1b153a504f',
@@ -319,11 +334,14 @@ PC_DECISION2ID = {
         'id_2d32235c-02d4-4686-88a6-96f4d6c7b1c3',
     'Store AIP location':
         'id_b320ce81-9982-408a-9502-097d0daa48fa',
+    'Store DIP':
+        'id_5e58066d-e113-4383-b20b-f301ed4d751c',
     'Store DIP location':
-        # 'id_b7a83da6-ed5a-47f7-a643-1e9f9f46e364',
         'id_cd844b6e-ab3c-4bc6-b34f-7103f88715de',
     'Upload DIP':
-        'id_92879a29-45bf-4f0b-ac43-e64474f0f2f9'
+        'id_92879a29-45bf-4f0b-ac43-e64474f0f2f9',
+    'Generate thumbnails':
+        'id_498f7a6d-1b8c-431a-aa5d-83f14f3c5e65',
 }
 
 # Namespace map for parsing METS XML.

--- a/amuser/urls.py
+++ b/amuser/urls.py
@@ -1,3 +1,9 @@
+# -*- coding: utf-8 -*-
+
+"""URLS used across the AMAUAT suite plus getters to help retrieve those values
+consistently in tests.
+"""
+
 AM_URLS = (
     ('get_admin_general_url', '{}administration/general/'),
     ('get_aip_in_archival_storage_url', '{}archival-storage/{}/'),
@@ -22,6 +28,7 @@ AM_URLS = (
     ('get_appraisal_url', '{}appraisal/'),
     ('get_transfer_url', '{}transfer/'),
     ('get_validation_commands_url', '{}fpr/fpcommand/validation/'),
+    ('get_aip_preview_url', '{}ingest/preview/aip/{}'),
 )
 
 SS_URLS = (
@@ -38,6 +45,7 @@ SS_URLS = (
     ('get_spaces_url', '{}spaces/'),
     ('get_spaces_create_url', '{}spaces/create/'),
     ('get_ss_login_url', '{}login/'),
-    ('get_ss_package_delete_request_url', '{}packages/package_delete_request/'),
+    ('get_ss_package_delete_request_url',
+     '{}packages/package_delete_request/'),
     ('get_ss_users_url', '{}administration/users/'),
 )

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -115,6 +115,13 @@ def step_impl(context):
         ' originals" is set to "No"\n'
         'And the processing config decision "Document empty directories"'
         ' is set to "No"\n'
+        'And the processing config decision "Generate thumbnails" is set to'
+        ' "No"\n'
+        'And the processing config decision "Upload DIP" is set to '
+        '"Do not upload DIP"\n'
+        'And the processing config decision "Store DIP" is set to '
+        '"Do not store"\n'
+        'And the processing config decision "Store AIP" is set to "None"\n'
     )
 
 


### PR DESCRIPTION
This commit adds a handful of HTML ids required for decision points
to be resolved when testing PID binding. The PID binding test has
been updated to use these constants.

* Resolves archivematica/issues#243
* Connected to: archivematica/issues#193

_Corrected, the tests work as per this extract from the console:_
```
@pid-binding
Feature: Archivematica's entities can be assigned PIDs with specified resolution properties. # features/core/pid-binding.feature:27
  Users of Archivematica want to be able to generate Persistent IDentifiers
  (PIDs)---in this case Handle System handles---for Files and SIP/DIPs (and
  possibly also Directories) processed by Archivematica. The PIDs are based on
  the UUIDs of the respective entity, i.e., "hdl:<NAMING_AUTHORITY>/<UUID>.
  Archivematica should document both the PIDs and the derivable PURLs as
  premis:objectIdentifierType in the MET file of the DIP/AIP. The user should
  be able to configure Archivematica so that the PID URL (PURL) of an
  Archivematica-processed entity will resolve to particular resolve URLs. In
  addition, it should be possible to set *qualified* PURLs (e.g., with GET
  query params appended) to resolve to distinct URLs (e.g., derivatives).
  Scenario Outline: Lucien wants to create an AIP with a METS file that documents the binding of persistent identifiers to all of the AIP's original files and directories, and to the AIP itself. -- @1.1 transfer sources  # features/core/pid-binding.feature:54
    Given a fully automated default processing config                                                                                                                                                                        # features/steps/steps.py:88
    And default processing configured to assign UUIDs to all directories                                                                                                                                                     # features/steps/uuids_for_directories_steps.py:137
    And default processing configured to bind PIDs                                                                                                                                                                           # features/steps/pid_binding_steps.py:14
    And a Handle server client configured to create qualified PURLs                                                                                                                                                          # features/steps/pid_binding_steps.py:20
    And a Handle server client configured to use the accession number as the PID for the AIP                                                                                                                                 # features/steps/pid_binding_steps.py:83
    When a transfer is initiated on directory ~/archivematica-sampledata/TestTransfers/acceptance-tests/pid-binding/hierarchy-with-empty-dir with accession number 42                                                        # features/steps/steps.py:369
    And the user waits for the "Store AIP (review)" decision point to appear during ingest                                                                                                                                   # features/steps/steps.py:214
    Then the AIP METS file documents PIDs, PURLs, and UUIDs for all files, directories and the package itself                                                                                                                # features/steps/pid_binding_steps.py:97
    And the empty directory in dir2/dir2a/dir2aiii is in the normative structMap and has identifiers                                                                                                                         # features/steps/pid_binding_steps.py:105
[Errno 2] No such file or directory: '/tmp/tmpkm5ypi6k'
[Errno 2] No such file or directory: '/tmp/tmpne69aly9'

1 feature passed, 0 failed, 19 skipped
1 scenario passed, 0 failed, 51 skipped
9 steps passed, 0 failed, 549 skipped, 0 undefined
Took 2m14.084s
```