### PR TITLE
Add black box test for transfer micro-services

### DIFF
--- a/features/black_box/reingest-aip.feature
+++ b/features/black_box/reingest-aip.feature
@@ -9,7 +9,7 @@ Feature: Alma wants to be able to re-ingest an AIP and have the reingest recorde
   Scenario: METS contains reingestion events
     Given an AIP has been reingested
     When the reingest processing is complete
-    Then there is a PREMIS reingestion event for each original object in the AIP METS
+    Then there is a reingestion event for each original object in the AIP METS
 
   Scenario: METS contains deleted files
     Given an AIP has been reingested

--- a/features/black_box/transfer-microservices.feature
+++ b/features/black_box/transfer-microservices.feature
@@ -1,0 +1,22 @@
+@black-box
+Feature: Alma wants to ensure that PREMIS events are recorded for all preservation events that occur during Transfer
+
+  Scenario: PREMIS event for virus scanning
+    Given an AIP has been created and stored
+    When the AIP is downloaded
+    Then there is a virus scanning event for each original object in the AIP METS
+
+  Scenario: PREMIS event for message digest calculation
+    Given an AIP has been created and stored
+    When the AIP is downloaded
+    Then there is a message digest calculation event for each original object in the AIP METS
+
+  Scenario: PREMIS event for file format identification
+    Given an AIP has been created and stored
+    When the AIP is downloaded
+    Then there is a file format identification event for each original object in the AIP METS
+
+  Scenario: PREMIS event for ingestion
+    Given an AIP has been created and stored
+    When the AIP is downloaded
+    Then there is an ingestion event for each original object in the AIP METS

--- a/features/steps/black_box_steps.py
+++ b/features/steps/black_box_steps.py
@@ -11,7 +11,7 @@ from __future__ import print_function, unicode_literals
 import os
 import time
 
-from behave import given, when, then
+from behave import given, when, then, use_step_matcher
 from lxml import etree
 import metsrw
 
@@ -298,10 +298,20 @@ def step_impl(context):
     )
 
 
-@then("there is a PREMIS reingestion event for each original object in the AIP METS")
-def step_impl(context):
-    event_type = "reingestion"
-    types = {"reingestion": "reingestion"}
+use_step_matcher("re")
+
+
+@then("there is a.? (?P<event_type>.*) event for each original object in the AIP METS")
+def step_impl(context, event_type):
+    # map the event types as written in the feature file
+    # to what AM outputs in the METS
+    types = {
+        "file format identification": "format identification",
+        "ingestion": "ingestion",
+        "message digest calculation": "message digest calculation",
+        "reingestion": "reingestion",
+        "virus scanning": "virus check",
+    }
     mets = metsrw.METSDocument.fromfile(context.aip_mets_location)
     original_files = [
         fsentry for fsentry in mets.all_files() if fsentry.use == "original"
@@ -312,6 +322,9 @@ def step_impl(context):
             event_type, fsentry.path
         )
         assert len(events) == 1, error
+
+
+use_step_matcher("parse")
 
 
 @then("there is a current and a superseded techMD for each original object")

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -515,9 +515,7 @@ def get_premis_events_by_type(entry, event_type):
 
 
 def get_path_before_sanitization(entry, transfer_contains_objects_dir=False):
-    clean_name_premis_events = [
-        ev for ev in entry.get_premis_events() if ev.type == "name cleanup"
-    ]
+    clean_name_premis_events = get_premis_events_by_type(entry, "name cleanup")
     if not clean_name_premis_events:
         result = entry.path
     else:


### PR DESCRIPTION
This implements the four **Transfer microservices** scenarios from https://docs.google.com/document/d/1KGTsuc9NV5yaq-lUY7CVK3XY33C21zS3Ykr-N-6gpEg/edit# that happen with any test data.

Testing the *PREMIS event for metadata extraction* and *PREMIS event for validation* would require an API endpoint for modifying the processing configuration.



Connects to https://github.com/archivematica/Issues/issues/562