### PR TITLE
Extend black-box test coverage using jobs API endpoint

### DIFF
--- a/features/black_box/checksum.feature
+++ b/features/black_box/checksum.feature
@@ -1,0 +1,13 @@
+@black-box
+Feature: Alma wants to verify checksums transmitted with a transfer to ensure that the transfer contents haven't been corrupted.
+
+  Scenario: External metadata checksums are verified
+    Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV"
+    When the transfer compliance is verified
+    Then the "Verify metadata directory checksums" job completes successfully
+
+  Scenario: External metadata checksums are not verified
+    Given a "standard" transfer type located in "TestTransfers/fixityCheckShouldFail"
+    When the transfer compliance is verified
+    Then the "Verify metadata directory checksums" job fails
+    And the "Failed transfer" microservice is executed

--- a/features/black_box/create-aip.feature
+++ b/features/black_box/create-aip.feature
@@ -6,7 +6,7 @@ Alma wants to be able to create AIPs from all of Archivematica's different trans
 Background: The storage service is configured with a transfer source that can see the archivematica-sampledata repository.
 
   Scenario: Generate an AIP using a standard transfer workflow
-    Given a "SampleTransfers/DemoTransferCSV" AIP has been created and stored
+    Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV"
     When the AIP is downloaded
     Then the AIP METS can be accessed and parsed by mets-reader-writer
     And the AIP conforms to expected content and structure
@@ -18,3 +18,17 @@ Background: The storage service is configured with a transfer source that can se
     And every object in the AIP has been assigned a UUID in the AIP METS
     And every object in the objects and metadata directories has an amdSec
     And every PREMIS event recorded in the AIP METS records the logged-in user, the organization and the software as PREMIS agents
+
+  Scenario: Generate an AIP using an unzipped transfer workflow
+    Given a "unzipped bag" transfer type located in "SampleTransfers/BagTransfer"
+    When the transfer is approved
+    Then the "Verify bag, and restructure for compliance" job completes successfully
+
+  Scenario: Generate an AIP using a Dataverse workflow
+    Given a "dataverse" transfer type located in "SampleTransfers/Dataverse/NDSAStaffingReport"
+    When the AIP is downloaded
+    Then the "Set convert Dataverse structure flag" job completes successfully
+    And the "Set parse Dataverse METS flag" job completes successfully
+    And the "Convert Dataverse structure" job completes successfully
+    And the "Parse Dataverse METS XML" job completes successfully
+    And the METS file contains a dmdSec with DDI metadata

--- a/features/black_box/extract-package.feature
+++ b/features/black_box/extract-package.feature
@@ -1,0 +1,18 @@
+@black-box
+Feature: Alma wants package files included in the transfer to be extracted.
+
+  Scenario: packages are extracted successfully
+    Given a "standard" transfer type located in "SampleTransfers/OfficeDocs"
+    When the transfer compliance is verified
+    Then the "Extract contents from compressed archives" job completes successfully
+    And the "Sanitize extracted objects' file and directory names" job completes successfully
+    And the "Remove cache files" job completes successfully
+    And the "Scan for viruses on extracted files" job completes successfully
+    And the "Identify file format" job completes successfully
+    And the "Determine if transfer still contains packages" job completes successfully
+
+  Scenario: packages are not extracted successfully
+    Given a "standard" transfer type located in "TestTransfers/broken_package_format_types"
+    When the transfer compliance is verified
+    Then the "Extract contents from compressed archives" job fails
+    And the "Failed transfer" microservice is executed

--- a/features/black_box/reingest-aip.feature
+++ b/features/black_box/reingest-aip.feature
@@ -2,7 +2,7 @@
 Feature: Alma wants to be able to re-ingest an AIP and have the reingest recorded accurately in the AIP METS file.
 
   Scenario: Reingest without error
-    Given a "SampleTransfers/DemoTransferCSV" AIP has been reingested
+    Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV" has been reingested
     When the reingest has been processed
     Then the AIP can be successfully stored
     And there is a reingestion event for each original object in the AIP METS

--- a/features/black_box/transfer-microservices.feature
+++ b/features/black_box/transfer-microservices.feature
@@ -2,7 +2,7 @@
 Feature: Alma wants to ensure that PREMIS events are recorded for all preservation events that occur during Transfer
 
   Scenario Outline: The minimum set of PREMIS events are recorded for a transfer
-    Given a "<sample_transfer_path>" AIP has been created and stored
+    Given a "standard" transfer type located in "<sample_transfer_path>"
     When the AIP is downloaded
     Then there is a virus scanning event for each original object in the AIP METS
     And there is a message digest calculation event for each original object in the AIP METS

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-amclient
+git+git://github.com/artefactual-labs/amclient@e779e45a0d31e1c576cd9279d792fec59a62c20f#egg=amclient
 behave>=1.0
 lxml
 metsrw


### PR DESCRIPTION
This PR adds feature files and scenarios for validating checksums, unzipped bag and dataverse transfers and package extraction through the new `jobs` API endpoint.

A feature file for file identification has been added without the `@black-box` label because currently it's not possible to set FPR commands/rules through the APIs. Similarly some scenarios were added and commented out in the `create-aip` feature file waiting for a fix for https://github.com/archivematica/Issues/issues/771

Some other changes done to the `black-box` steps and utility functions:

- Adds a transfer type parameter to the give steps
- Allows failed transfers/ingest to be used
- Allows browse paths that reference files (like in a zipped bag transfer)
- Clarifies the error message when transfer paths are incorrect

Connected to https://github.com/archivematica/Issues/issues/722