### PR TITLE
Correct PID binding tests

### DIFF
--- a/amuser/am_browser_ability.py
+++ b/amuser/am_browser_ability.py
@@ -451,7 +451,7 @@ class ArchivematicaBrowserAbility(
         )
         self.set_processing_config_decision(
             decision_label="Select file format identification command (Ingest)",
-            choice_value="Use existing data",
+            choice_value="No, use existing data",
         )
         self.set_processing_config_decision(
             decision_label="Normalize", choice_value="None"

--- a/amuser/am_mets_ability.py
+++ b/amuser/am_mets_ability.py
@@ -152,15 +152,15 @@ def _add_entity_identifiers(entity, doc, ns):
         obj_idfr_els = amd_sec_el.findall(
             ".//mets:mdWrap/"
             "mets:xmlData/"
-            "premis:object/"
-            "premis:objectIdentifier",
+            "premis3:object/"
+            "premis3:objectIdentifier",
             ns,
         )
         for obj_idfr_el in obj_idfr_els:
             identifiers.append(
                 (
-                    obj_idfr_el.find("premis:objectIdentifierType", ns).text,
-                    obj_idfr_el.find("premis:objectIdentifierValue", ns).text,
+                    obj_idfr_el.find("premis3:objectIdentifierType", ns).text,
+                    obj_idfr_el.find("premis3:objectIdentifierValue", ns).text,
                 )
             )
     else:

--- a/features/core/pid-binding.feature
+++ b/features/core/pid-binding.feature
@@ -45,7 +45,7 @@ Feature: Archivematica's entities can be assigned PIDs with specified resolution
     And a Handle server client configured to create qualified PURLs
     And a Handle server client configured to use the accession number as the PID for the AIP
     When a transfer is initiated on directory <directory_path> with accession number <accession_no>
-    And the user waits for the "Store AIP (review)" decision point to appear during ingest
+    And the user waits for the AIP to appear in archival storage
     Then the AIP METS file documents PIDs, PURLs, and UUIDs for all files, directories and the package itself
     And the empty directory in <empty_dir_rel_path> is in the normative structMap and has identifiers
 

--- a/features/steps/pid_binding_steps.py
+++ b/features/steps/pid_binding_steps.py
@@ -97,8 +97,7 @@ def step_impl(context):
 
 
 @given(
-    "a Handle server client configured to use the accession number as the"
-    " PID for the AIP"
+    "a Handle server client configured to use the accession number as the PID for the AIP"
 )
 def step_impl(context):
     context.am_user.browser.configure_handle(
@@ -115,18 +114,16 @@ def step_impl(context):
 
 
 @then(
-    "the AIP METS file documents PIDs, PURLs, and UUIDs for all files,"
-    " directories and the package itself"
+    "the AIP METS file documents PIDs, PURLs, and UUIDs for all files, directories and the package itself"
 )
 def step_impl(context):
     accession_no = getattr(context.scenario, "accession_no", None)
-    mets = context.scenario.mets = utils.get_mets_from_scenario(context)
+    mets = context.scenario.mets = utils.get_mets_from_scenario(context, api=True)
     context.am_user.mets.validate_mets_for_pids(mets, accession_no=accession_no)
 
 
 @then(
-    "the empty directory in {empty_dir_rel_path} is in the normative"
-    " structMap and has identifiers"
+    "the empty directory in {empty_dir_rel_path} is in the normative structMap and has identifiers"
 )
 def step_impl(context, empty_dir_rel_path):
     mets = context.scenario.mets

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -16,8 +16,7 @@ logger = logging.getLogger("amauat.steps")
 
 
 @given(
-    'the user waits for the "{microservice_name}" micro-service to complete'
-    " during {unit_type}"
+    'the user waits for the "{microservice_name}" micro-service to complete during {unit_type}'
 )
 def step_impl(context, microservice_name, unit_type):
     utils.wait_for_micro_service_to_complete(context, microservice_name, unit_type)
@@ -42,8 +41,7 @@ def step_impl(context, choice, decision_point, unit_type):
 @given("the default processing config is in its default state")
 def step_impl(context):
     context.execute_steps(
-        "Given that the user has ensured that the default processing config is"
-        " in its default state"
+        "Given that the user has ensured that the default processing config is in its default state"
     )
 
 
@@ -106,36 +104,22 @@ def step_impl(context):
     feature.
     """
     context.execute_steps(
-        "Given that the user has ensured that the default processing config is"
-        " in its default state\n"
-        'And the processing config decision "Select file format identification'
-        ' command (Transfer)" is set to "Identify using Fido"\n'
-        'And the processing config decision "Create SIP(s)" is set to "Create'
-        ' single SIP and continue processing"\n'
-        'And the processing config decision "Select file format identification'
-        ' command (Ingest)" is set to "Identify using Fido"\n'
-        'And the processing config decision "Normalize" is set to "Normalize'
-        ' for preservation and access"\n'
-        'And the processing config decision "Approve normalization" is set to'
-        ' "Yes"\n'
-        'And the processing config decision "Select file format identification'
-        ' command (Submission documentation & metadata)" is set to'
-        ' "Identify using Fido"\n'
-        'And the processing config decision "Perform policy checks on'
-        ' preservation derivatives" is set to "No"\n'
-        'And the processing config decision "Perform policy checks on access'
-        ' derivatives" is set to "No"\n'
-        'And the processing config decision "Perform policy checks on'
-        ' originals" is set to "No"\n'
-        'And the processing config decision "Document empty directories"'
-        ' is set to "No"\n'
-        'And the processing config decision "Generate thumbnails" is set to'
-        ' "No"\n'
-        'And the processing config decision "Upload DIP" is set to'
-        ' "Do not upload DIP"\n'
-        'And the processing config decision "Store DIP" is set to'
-        ' "Do not store"\n'
-        'And the processing config decision "Store AIP" is set to "None"\n'
+        "Given that the user has ensured that the default processing config is in its default state\n"
+        'And the processing config decision "Select file format identification command (Transfer)" is set to "Yes"\n'
+        'And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"\n'
+        'And the processing config decision "Select file format identification command (Ingest)" is set to "Yes"\n'
+        'And the processing config decision "Normalize" is set to "Normalize for preservation and access"\n'
+        'And the processing config decision "Approve normalization" is set to "Yes"\n'
+        'And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Yes"\n'
+        'And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"\n'
+        'And the processing config decision "Perform policy checks on access derivatives" is set to "No"\n'
+        'And the processing config decision "Perform policy checks on originals" is set to "No"\n'
+        'And the processing config decision "Document empty directories" is set to "No"\n'
+        'And the processing config decision "Generate thumbnails" is set to "No"\n'
+        'And the processing config decision "Upload DIP" is set to "Do not upload DIP"\n'
+        'And the processing config decision "Store DIP" is set to "Do not store"\n'
+        'And the processing config decision "Store AIP" is set to "Yes"\n'
+        'And the processing config decision "Store AIP location" is set to "Default location"\n'
     )
 
 
@@ -146,27 +130,16 @@ def step_impl(context):
 def step_impl(context):
     context.execute_steps(
         "Given the default processing config is in its default state\n"
-        'And the processing config decision "Assign UUIDs to directories" is'
-        ' set to "No"\n'
-        'And the processing config decision "Document empty directories" is'
-        ' set to "No"\n'
-        'And the processing config decision "Select file format identification'
-        ' command (Transfer)" is set to "Identify using Siegfried"\n'
-        'And the processing config decision "Perform policy checks on'
-        ' originals" is set to "No"\n'
-        'And the processing config decision "Create SIP(s)" is set to "Create'
-        ' single SIP and continue processing"\n'
-        'And the processing config decision "Normalize" is set to "Normalize'
-        ' for preservation"\n'
-        'And the processing config decision "Approve normalization" is set to'
-        ' "Yes"\n'
-        'And the processing config decision "Perform policy checks on'
-        ' preservation derivatives" is set to "No"\n'
-        'And the processing config decision "Perform policy checks on access'
-        ' derivatives" is set to "No"\n'
-        'And the processing config decision "Select file format identification'
-        ' command (Submission documentation & metadata)" is set to'
-        ' "Identify using Siegfried"\n'
+        'And the processing config decision "Assign UUIDs to directories" is set to "No"\n'
+        'And the processing config decision "Document empty directories" is set to "No"\n'
+        'And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Siegfried"\n'
+        'And the processing config decision "Perform policy checks on originals" is set to "No"\n'
+        'And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"\n'
+        'And the processing config decision "Normalize" is set to "Normalize for preservation"\n'
+        'And the processing config decision "Approve normalization" is set to "Yes"\n'
+        'And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"\n'
+        'And the processing config decision "Perform policy checks on access derivatives" is set to "No"\n'
+        'And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Siegfried"\n'
         'And the processing config decision "Bind PIDs" is set to "No"'
     )
 
@@ -175,31 +148,19 @@ def step_impl(context):
 def step_impl(context):
     context.execute_steps(
         "Given the default processing config is in its default state\n"
-        'And the processing config decision "Document empty directories" is'
-        ' set to "No"\n'
-        'And the processing config decision "Assign UUIDs to directories" is'
-        ' set to "No"\n'
-        'And the processing config decision "Select file format identification'
-        ' command (Transfer)" is set to "Identify using Siegfried"\n'
-        'And the processing config decision "Perform policy checks on'
-        ' originals" is set to "No"\n'
-        'And the processing config decision "Create SIP(s)" is set to "Create'
-        ' single SIP and continue processing"\n'
-        'And the processing config decision "Normalize" is set to "Normalize'
-        ' for preservation"\n'
-        'And the processing config decision "Approve normalization" is set to'
-        ' "Yes"\n'
-        'And the processing config decision "Perform policy checks on'
-        ' preservation derivatives" is set to "No"\n'
-        'And the processing config decision "Perform policy checks on access'
-        ' derivatives" is set to "No"\n'
-        'And the processing config decision "Select file format identification'
-        ' command (Submission documentation & metadata)" is set to'
-        ' "Identify using Siegfried"\n'
+        'And the processing config decision "Document empty directories" is set to "No"\n'
+        'And the processing config decision "Assign UUIDs to directories" is set to "No"\n'
+        'And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Siegfried"\n'
+        'And the processing config decision "Perform policy checks on originals" is set to "No"\n'
+        'And the processing config decision "Create SIP(s)" is set to "Create single SIP and continue processing"\n'
+        'And the processing config decision "Normalize" is set to "Normalize for preservation"\n'
+        'And the processing config decision "Approve normalization" is set to "Yes"\n'
+        'And the processing config decision "Perform policy checks on preservation derivatives" is set to "No"\n'
+        'And the processing config decision "Perform policy checks on access derivatives" is set to "No"\n'
+        'And the processing config decision "Select file format identification command (Submission documentation & metadata)" is set to "Identify using Siegfried"\n'
         'And the processing config decision "Bind PIDs" is set to "No"\n'
         'And the processing config decision "Store AIP" is set to "Yes"\n'
-        'And the processing config decision "Store AIP location" is set to'
-        ' "Default location"\n'
+        'And the processing config decision "Store AIP location" is set to "Default location"\n'
     )
 
 
@@ -210,12 +171,9 @@ def step_impl(context):
 def step_impl(context):
     context.execute_steps(
         "Given the default processing config is in its default state\n"
-        'And the processing config decision "Assign UUIDs to directories" is'
-        ' set to "No"\n'
-        'And the processing config decision "Select file format identification'
-        ' command (Transfer)" is set to "Identify using Siegfried"\n'
-        'And the processing config decision "Perform policy checks on'
-        ' originals" is set to "No"\n'
+        'And the processing config decision "Assign UUIDs to directories" is set to "No"\n'
+        'And the processing config decision "Select file format identification command (Transfer)" is set to "Identify using Siegfried"\n'
+        'And the processing config decision "Perform policy checks on originals" is set to "No"\n'
     )
 
 
@@ -367,35 +325,18 @@ def step_impl(context):
     - store AIP
     """
     context.execute_steps(
-        'When the user waits for the "Assign UUIDs to directories?" decision'
-        ' point to appear and chooses "No" during transfer\n'
-        'And the user waits for the "Select file format identification command"'
-        ' decision point to appear and chooses "Identify using Siegfried" during'
-        " transfer\n"
-        'And the user waits for the "Perform policy checks on originals?"'
-        ' decision point to appear and chooses "No" during transfer\n'
-        'And the user waits for the "Create SIP(s)" decision point to appear'
-        ' and chooses "Create single SIP and continue processing" during'
-        " transfer\n"
-        'And the user waits for the "Normalize" decision point to appear and'
-        ' chooses "Normalize for preservation" during ingest\n'
-        'And the user waits for the "Approve normalization (review)" decision'
-        ' point to appear and chooses "Approve" during ingest\n'
-        'And the user waits for the "Perform policy checks on preservation'
-        ' derivatives?" decision point to appear and chooses "No" during'
-        " ingest\n"
-        'And the user waits for the "Perform policy checks on access'
-        ' derivatives?" decision point to appear and chooses "No" during'
-        " ingest\n"
-        'And the user waits for the "Select file format identification'
-        ' command|Process submission documentation" decision point to'
-        ' appear and chooses "Identify using Siegfried" during ingest\n'
-        'And the user waits for the "Bind PIDs?" decision point to appear and'
-        ' chooses "No" during ingest\n'
-        'And the user waits for the "Document empty directories?" decision'
-        ' point to appear and chooses "No" during ingest\n'
-        'And the user waits for the "Store AIP (review)" decision point to'
-        ' appear and chooses "Store AIP" during ingest'
+        'When the user waits for the "Assign UUIDs to directories?" decision point to appear and chooses "No" during transfer\n'
+        'And the user waits for the "Select file format identification command" decision point to appear and chooses "Identify using Siegfried" during transfer\n'
+        'And the user waits for the "Perform policy checks on originals?" decision point to appear and chooses "No" during transfer\n'
+        'And the user waits for the "Create SIP(s)" decision point to appear and chooses "Create single SIP and continue processing" during transfer\n'
+        'And the user waits for the "Normalize" decision point to appear and chooses "Normalize for preservation" during ingest\n'
+        'And the user waits for the "Approve normalization (review)" decision point to appear and chooses "Approve" during ingest\n'
+        'And the user waits for the "Perform policy checks on preservation derivatives?" decision point to appear and chooses "No" during ingest\n'
+        'And the user waits for the "Perform policy checks on access derivatives?" decision point to appear and chooses "No" during ingest\n'
+        'And the user waits for the "Select file format identification command|Process submission documentation" decision point to appear and chooses "Identify using Siegfried" during ingest\n'
+        'And the user waits for the "Bind PIDs?" decision point to appear and chooses "No" during ingest\n'
+        'And the user waits for the "Document empty directories?" decision point to appear and chooses "No" during ingest\n'
+        'And the user waits for the "Store AIP (review)" decision point to appear and chooses "Store AIP" during ingest'
     )
 
 
@@ -438,33 +379,18 @@ def step_impl(context):
     """
     context.execute_steps(
         "When the user initiates a metadata-only re-ingest on the AIP\n"
-        'And the user waits for the "Approve AIP reingest" decision point to'
-        ' appear and chooses "Approve AIP reingest" during ingest\n'
-        'And the user waits for the "Normalize" decision point to appear and'
-        ' chooses "Do not normalize" during ingest\n'
-        'And the user waits for the "Perform policy checks on preservation'
-        ' derivatives?" decision point to appear and chooses "No" during'
-        " ingest\n"
-        'And the user waits for the "Perform policy checks on access'
-        ' derivatives?" decision point to appear and chooses "No" during'
-        " ingest\n"
-        'And the user waits for the "Reminder: add metadata if desired"'
-        " decision point to appear during ingest\n"
+        'And the user waits for the "Approve AIP reingest" decision point to appear and chooses "Approve AIP reingest" during ingest\n'
+        'And the user waits for the "Normalize" decision point to appear and chooses "Do not normalize" during ingest\n'
+        'And the user waits for the "Perform policy checks on preservation derivatives?" decision point to appear and chooses "No" during ingest\n'
+        'And the user waits for the "Perform policy checks on access derivatives?" decision point to appear and chooses "No" during ingest\n'
+        'And the user waits for the "Reminder: add metadata if desired" decision point to appear during ingest\n'
         "And the user adds metadata\n"
-        'And the user chooses "Continue" at decision point "Reminder: add'
-        ' metadata if desired" during ingest\n'
-        'And the user waits for the "Select file format identification'
-        ' command|Process submission documentation" decision point to appear'
-        ' and chooses "Identify using Fido" during ingest\n'
-        'And the user waits for the "Bind PIDs?" decision point to appear'
-        ' and chooses "No" during ingest\n'
-        'And the user waits for the "Document empty directories?" decision'
-        ' point to appear and chooses "No" during ingest\n'
-        'And the user waits for the "Store AIP (review)" decision point to'
-        ' appear and chooses "Store AIP" during ingest\n'
-        'And the user waits for the "Store AIP location" decision point to'
-        ' appear and chooses "Store AIP Encrypted in standard Archivematica'
-        ' Directory" during ingest\n'
+        'And the user chooses "Continue" at decision point "Reminder: add metadata if desired" during ingest\n'
+        'And the user waits for the "Select file format identification command|Process submission documentation" decision point to appear and chooses "Identify using Fido" during ingest\n'
+        'And the user waits for the "Bind PIDs?" decision point to appear and chooses "No" during ingest\n'
+        'And the user waits for the "Document empty directories?" decision point to appear and chooses "No" during ingest\n'
+        'And the user waits for the "Store AIP (review)" decision point to appear and chooses "Store AIP" during ingest\n'
+        'And the user waits for the "Store AIP location" decision point to appear and chooses "Store AIP Encrypted in standard Archivematica Directory" during ingest\n'
         "And the user waits for the AIP to appear in archival storage"
     )
 

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -85,7 +85,20 @@ def get_event_attr(event_type):
     return "{}_event_uuid".format(event_type)
 
 
-def get_mets_from_scenario(context):
+def get_mets_from_scenario(context, api=False):
+    """Retrieve the AIP METS file from the test scenario
+
+    Given a parameter of True for the api parameter, then we will seek to
+    retrieve the AIP METS from the AIP package itself. When that parameter is
+    False, we will seek to download it via the web-driver from the Store AIP
+    decision point on the ingest tab of Archivematica where the user has the
+    opportunity to review the METS file from the browser window.
+    """
+    if api:
+        return context.am_user.browser.get_mets_via_api(
+            context.scenario.transfer_name,
+            context.am_user.browser.get_sip_uuid(context.scenario.transfer_name),
+        )
     return context.am_user.browser.get_mets(
         context.scenario.transfer_name,
         context.am_user.browser.get_sip_uuid(context.scenario.transfer_name),


### PR DESCRIPTION
In this commit we make a handful of small changes to make the PID
binding tests pass and slowly start moving to making further use of
AMClient API calls. In this instance, we enable the download of
AIP METS from a Archival Information Package without having to read
it via the selenium driver in the Archivematica ingest browser.

Connected to archivematica/issues#133
Connected to archivematica/issues#777