### PR TITLE
Add capability to test AM's virus handling

### DIFF
--- a/features/black_box/virus.feature
+++ b/features/black_box/virus.feature
@@ -1,0 +1,13 @@
+@black-box
+Feature: Alma wants to ensure that virus scanning in Archivematica works correctly to ensure transfers pass when they have no viruses, and transfers fail when they contain viruses.
+
+  Scenario: Virus checks for a transfer pass
+    Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV"
+    When the transfer compliance is verified
+    Then the "Scan for viruses" job completes successfully
+
+  Scenario: Virus checks for a transfer fail
+    Given a "standard" transfer type located in "TestTransfers/virusTests"
+    When the transfer compliance is verified
+    Then the "Scan for viruses" job fails
+    And the "Failed transfer" microservice is executed


### PR DESCRIPTION
This is a feature to test Archivematica's virus handling. It will
test the successful triggering of a transfer failure i.e. when there
is a virus. It will also test that a transfer passes checking when
there is no virus.

The test successfully passes against `1.10`. 
```feature
@black-box
Feature: Alma wants to ensure that virus scanning in Archivematica works correctly to ensure transfers pass when they have no viruses, and transfers fail when they contain viruses. # features/black_box/virus.feature:2

  Scenario: Virus checks for a transfer pass                                      # features/black_box/virus.feature:4
    Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV" # features/steps/black_box_steps.py:44 0.001s
    When the transfer compliance is verified                                      # features/steps/black_box_steps.py:81 0.048s
    Then the "Scan for viruses" job completes successfully                        # features/steps/black_box_steps.py:403 0.025s

  Scenario: Virus checks for a transfer fail                               # features/black_box/virus.feature:9
    Given a "standard" transfer type located in "TestTransfers/virusTests" # features/steps/black_box_steps.py:44 12.223s
    When the transfer compliance is verified                               # features/steps/black_box_steps.py:81 0.030s
    Then the "Scan for viruses" job fails                                  # features/steps/black_box_steps.py:420 0.020s
    And the "Failed transfer" microservice is executed                     # features/steps/black_box_steps.py:429 0.020s

6 features passed, 0 failed, 20 skipped
12 scenarios passed, 0 failed, 52 skipped
68 steps passed, 0 failed, 558 skipped, 0 undefined
Took 9m54.202s
```

Connected to archivematica/issues#879 