### PR TITLE
Black-box: Expand features tested around unzipped bags

### DIFF
--- a/features/black_box/create-aip.feature
+++ b/features/black_box/create-aip.feature
@@ -19,10 +19,11 @@ Background: The storage service is configured with a transfer source that can se
     And every object in the objects and metadata directories has an amdSec
     And every PREMIS event recorded in the AIP METS records the logged-in user, the organization and the software as PREMIS agents
 
-  Scenario: Generate an AIP using an unzipped transfer workflow
+  Scenario: Generate an AIP using an unzipped bag transfer workflow
     Given a "unzipped bag" transfer type located in "SampleTransfers/BagTransfer"
     When the transfer is approved
     Then the "Verify bag, and restructure for compliance" job completes successfully
+    And there is a sourceMD containing a BagIt mdWrap in the AIP METS
 
   Scenario: Generate an AIP using a Dataverse workflow
     Given a "dataverse" transfer type located in "SampleTransfers/Dataverse/NDSAStaffingReport"

--- a/features/black_box/reingest-aip.feature
+++ b/features/black_box/reingest-aip.feature
@@ -8,3 +8,12 @@ Feature: Alma wants to be able to re-ingest an AIP and have the reingest recorde
     And there is a reingestion event for each original object in the AIP METS
     And there is a fileSec for deleted files for objects that were re-normalized
     And there is a current and a superseded techMD for each original object
+
+Scenario: Reingest unzipped bag transfer
+    Given a "unzipped bag" transfer type located in "SampleTransfers/UnzippedBag" has been reingested
+    When the reingest has been processed
+    Then the AIP can be successfully stored
+    And there is a reingestion event for each original object in the AIP METS
+    And there is a fileSec for deleted files for objects that were re-normalized
+    And there is a current and a superseded techMD for each original object
+    And there is a sourceMD containing a BagIt mdWrap in the reingested AIP METS

--- a/features/steps/black_box_steps.py
+++ b/features/steps/black_box_steps.py
@@ -369,6 +369,21 @@ def step_impl(context):
         assert techmds_status == ["current", "superseded"], error
 
 
+@then("there is a sourceMD containing a BagIt mdWrap in the AIP METS")
+def step_impl(context):
+    utils.assert_source_md_in_bagit_mets(
+        etree.parse(context.current_transfer["aip_mets_location"]), context.mets_nsmap
+    )
+
+
+@then("there is a sourceMD containing a BagIt mdWrap in the reingested AIP METS")
+def step_impl(context):
+    utils.assert_source_md_in_bagit_mets(
+        etree.parse(context.current_transfer["reingest_aip_mets_location"]),
+        context.mets_nsmap,
+    )
+
+
 @then("there is a fileSec for deleted files for objects that were re-normalized")
 def step_impl(context):
     # get files that were deleted after reingest

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -844,3 +844,28 @@ def assert_microservice_executes(api_clients_config, unit_uuid, microservice_nam
     assert len(jobs), "No jobs found with microservice {} for unit {}".format(
         microservice_name, unit_uuid
     )
+
+
+def assert_source_md_in_bagit_mets(mets_root, mets_nsmap):
+    EXPECTED_SOURCE_MD_ELEMS = 1
+    BAGITMDTYPE = "BagIt"
+    source_md_elem = mets_root.xpath("mets:amdSec/mets:sourceMD", namespaces=mets_nsmap)
+    # Initial assertions about the sourceMD element.
+    assert source_md_elem, "sourceMD cannot be found, sourceMD is None"
+    assert (
+        len(source_md_elem) is EXPECTED_SOURCE_MD_ELEMS
+    ), "sourceMD count is incorrect: {}".format(len(source_md_elem))
+    md_wrap_elems = source_md_elem[0].xpath("mets:mdWrap", namespaces=mets_nsmap)
+    # Assert the metadata type is associated with BagIt.
+    assert md_wrap_elems
+    md_type = md_wrap_elems[0].attrib["OTHERMDTYPE"]
+    assert md_type == BAGITMDTYPE, "Metadata type is incorrect: {}".format(md_type)
+    # Assert there is a transfer metadata snippet, and it's not empty.
+    transfer_md = md_wrap_elems[0].xpath(
+        "mets:xmlData/transfer_metadata", namespaces=mets_nsmap
+    )
+    assert transfer_md, "Cannot find transfer_metadata element"
+    element_count = len(transfer_md[0])
+    assert element_count > 0, "No elements in BagIt transfer metadata: {}".format(
+        element_count
+    )


### PR DESCRIPTION
Data in bag transfers also augments the METS that is output in the
AIP. These tests will help generate assurance this data persists
at ingest, and following re-ingest.

Connected to archivematica/issues#914 