### PR TITLE
Rename compression option to be consistent

### DIFF
--- a/amuser/am_browser_ability.py
+++ b/amuser/am_browser_ability.py
@@ -470,7 +470,7 @@ class ArchivematicaBrowserAbility(
         )
         self.set_processing_config_decision(
             decision_label="Select compression level",
-            choice_value="5 - normal compression mode",
+            choice_value="5 - normal compression",
         )
         self.set_processing_config_decision(
             decision_label="Store AIP", choice_value="None"


### PR DESCRIPTION
Processing configuration options have been updated in 1.11 and so
this change ensures that the tests will still work as a result of
that.

Connected to artefactual/archivematica#891

**NB.** This should be the only change required from [here](https://github.com/artefactual/archivematica/pull/1502/files)

Required by https://github.com/artefactual/archivematica/pull/1502