### PR TITLE
Add Dublin Core tests to Standard Transfer

### DIFF
--- a/features/black_box/description-rights.feature
+++ b/features/black_box/description-rights.feature
@@ -15,4 +15,6 @@ Feature: Alma wants to ensure the AIP METS contains metadata from description an
 
     Examples: sample transfers
       | sample_transfer_path            | original_object_count | directory_count | original_object_rights_count | rights_entries_count | submission_documents_count |
-      | SampleTransfers/DemoTransferCSV | 7                     | 2               | 2                            | 8                    | 1                          |
+      | SampleTransfers/DemoTransferCSV | 7                     | 1               | 2                            | 8                    | 1                          |
+      | SampleTransfers/CSVmultiLevel   | 4                     | 1               | 0                            | 0                    | 0                          |
+      | TestTransfers/rightsTransfer    | 0                     | 0               | 2                            | 4                    | 0                          |

--- a/features/black_box/description-rights.feature
+++ b/features/black_box/description-rights.feature
@@ -1,0 +1,18 @@
+@black-box @black-box-metadata
+Feature: Alma wants to ensure the AIP METS contains metadata from description and rights CSVs
+
+  Background: metadata.csv and rights.csv are two reserved files that can be associated with a transfer these files contain information that should be transcribed to metadata elements in the METS.xml in the resulting AIP
+
+  Scenario Outline: Descriptive and rights metadata are listed in the AIP METS and submission documentation is listed correctly
+    Given a "standard" transfer type located in "<sample_transfer_path>"
+    When the AIP is downloaded
+    Then the AIP METS can be accessed and parsed by mets-reader-writer
+    And there are <original_object_count> original objects in the AIP METS with a DMDSEC containing DC metadata
+    And there are <directory_count> directories in the AIP METS with a DMDSEC containing DC metadata
+    And there are <original_object_rights_count> objects in the AIP METS with a rightsMD section containing PREMIS:RIGHTS
+    And there are <rights_entries_count> PREMIS:RIGHTS entries
+    And there are <submission_documents_count> submission documents listed in the AIP METS as submission documentation
+
+    Examples: sample transfers
+      | sample_transfer_path            | original_object_count | directory_count | original_object_rights_count | rights_entries_count | submission_documents_count |
+      | SampleTransfers/DemoTransferCSV | 7                     | 2               | 2                            | 8                    | 1                          |

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -568,21 +568,19 @@ def get_premis_events_by_type(entry, event_type):
 
 def get_transfer_dir_from_structmap(tree, transfer_name, sip_uuid, nsmap):
     structmap = tree.find('mets:structMap[@TYPE="physical"]', namespaces=nsmap)
-    transfer_dir = structmap.find(
+    return structmap.find(
         'mets:div[@LABEL="{}-{}"][@TYPE="Directory"]'.format(transfer_name, sip_uuid),
         namespaces=nsmap,
     )
-    return transfer_dir
 
 
-def get_submission_docs_from_structmap(tree, nsmap):
-    label = "submissionDocumentation"
-    structmap = tree.find('mets:structMap[@TYPE="physical"]', namespaces=nsmap)
-    transfer_dir = structmap.find(
-        '*//mets:div[@LABEL="{}"][@TYPE="Directory"]'.format(label), namespaces=nsmap
+def get_submission_docs_from_structmap(tree, transfer_name, sip_uuid, nsmap):
+    transfer_dir = get_transfer_dir_from_structmap(tree, transfer_name, sip_uuid, nsmap)
+    return transfer_dir.findall(
+        'mets:div[@LABEL="objects"]/mets:div[@LABEL="submissionDocumentation"]'
+        '//mets:div[@TYPE="Item"]',
+        namespaces=nsmap,
     )
-    submission_docs = transfer_dir.findall("*//mets:div", namespaces=nsmap)
-    return set([doc.get("LABEL") for doc in submission_docs])
 
 
 def get_path_before_sanitization(entry, transfer_contains_objects_dir=False):


### PR DESCRIPTION
This submission creates a new tag `@black-box-metadata` for testing whether DC metadata, Rights metadata, and submission documentation was correctly associated with a transfer. 

Connected to archivematica/issues#1073
Requires https://github.com/artefactual/archivematica-sampledata/pull/68

-----

_**Original testing notes from 2020**_

_This seemed worthy of investigation and hopefully this is seen as a good addition to the test-suite  as it would have captured two issues in Archivematica early on. (Indeed, the new unit tests associated with 1073 will help there as well). The commits below tell the story for AMAUAT:_

* _https://github.com/artefactual/archivematica/commit/9ec86dc8b7ac9dd2f63d18d29ccd3329ddd086e8 <-- And if you test with this commit, you will see Douglas' work pay-off and all works as anticipated once again. 
* https://github.com/artefactual/archivematica/commit/2acad6baaeb9dce13ac8e930555c4d196d478e76 <-- If you test with this you will detect Archivematica doesn't create DC metadata entries for the same file with diacritics in. 
* https://github.com/artefactual/archivematica/commit/81e3ebbd210cb9c98120146951569bfd7e02ad39 <-- If you test with this you will detect Archivematica doesn't process a transfer with diacritics in a filename._ 

_The sample-data associated with https://github.com/artefactual/archivematica-sampledata/pull/68 adds a new file, plus metadata to our two primary demo transfers. To help with our testing, all transfer objects are described and so we now anticipate metadata for each entry._ 

_More generally, DC entries are shallowly tested for their existence now, and these tests should prove their existence for transfer directory objects - files, and directories._ 
