### PR TITLE
Restore reencrypt-different-key tag

### DIFF
--- a/features/core/aip-encryption.feature
+++ b/features/core/aip-encryption.feature
@@ -96,3 +96,12 @@ Feature: AIP Encryption
     When the AIP is deleted
     And the user attempts to delete the new GPG key
     Then the user succeeds in deleting the GPG key
+
+  @reencrypt-different-key
+  Scenario: Richard wants to confirm that he can re-encrypt an encrypted AIP with a new key. He has encrypted an AIP with GPG key A in space S. He later changed space S to use the more secure GPG key B. He wants to decrypt the AIPs encrypted with A and re-encrypt them with key B. Finally, he wants to delete the now unused key A from the storage service.
+    Given an encrypted AIP in the standard GPG-encrypted space
+    And the reminder to add metadata is enabled
+    When the user creates a new GPG key and assigns it to the standard GPG-encrypted space
+    And the user performs a metadata-only re-ingest on the AIP
+    And the user downloads the AIP pointer file
+    Then the AIP pointer file references the fingerprint of the new GPG key

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -460,18 +460,10 @@ def step_impl(context):
     context.execute_steps(
         "When the user initiates a metadata-only re-ingest on the AIP\n"
         'And the user waits for the "Approve AIP reingest" decision point to appear and chooses "Approve AIP reingest" during ingest\n'
-        'And the user waits for the "Normalize" decision point to appear and chooses "Do not normalize" during ingest\n'
-        'And the user waits for the "Perform policy checks on preservation derivatives?" decision point to appear and chooses "No" during ingest\n'
-        'And the user waits for the "Perform policy checks on access derivatives?" decision point to appear and chooses "No" during ingest\n'
         'And the user waits for the "Reminder: add metadata if desired" decision point to appear during ingest\n'
         "And the user adds metadata\n"
         'And the user chooses "Continue" at decision point "Reminder: add metadata if desired" during ingest\n'
         # TODO: change the below step to 'Perform file format identification ...' post 1.8 if fixing-up this test.
-        'And the user waits for the "Select file format identification command|Process submission documentation" decision point to appear and chooses "Identify using Fido" during ingest\n'
-        'And the user waits for the "Bind PIDs?" decision point to appear and chooses "No" during ingest\n'
-        'And the user waits for the "Document empty directories?" decision point to appear and chooses "No" during ingest\n'
-        'And the user waits for the "Store AIP (review)" decision point to appear and chooses "Store AIP" during ingest\n'
-        'And the user waits for the "Store AIP location" decision point to appear and chooses "Store AIP Encrypted in standard Archivematica Directory" during ingest\n'
         "And the user waits for the AIP to appear in archival storage"
     )
 


### PR DESCRIPTION
This PR restores the deprecated `reencrypt-different-key` AMAUAT to test GPG reencryption through reingest.

The Storage Service branch in https://github.com/artefactual/archivematica-storage-service/pull/518 is needed for this to pass.

Connected to https://github.com/archivematica/Issues/issues/803