### PR TITLE
Add scenario for creating Dspace transfers

### DIFF
--- a/features/black_box/create-aip.feature
+++ b/features/black_box/create-aip.feature
@@ -33,3 +33,10 @@ Background: The storage service is configured with a transfer source that can se
     And the "Convert Dataverse structure" job completes successfully
     And the "Parse Dataverse METS XML" job completes successfully
     And the METS file contains a dmdSec with DDI metadata
+
+  Scenario: Generate an AIP using a Dspace transfer workflow
+    Given a "dspace" transfer type located in "SampleTransfers/DSpaceExport/ITEM@2429-2700.zip"
+    When the AIP is downloaded
+    Then the "Identify DSpace mets files" job completes successfully
+    And the "Identify DSpace text files" job completes successfully
+    And the "Verify checksums in fileSec of DSpace METS files" job completes successfully


### PR DESCRIPTION
This is based and adjusted from an scenario we left out when we were extending the `black-box` test coverage. For more context see this https://github.com/artefactual-labs/archivematica-acceptance-tests/pull/143#issuecomment-514282054 

The associated change in AM is available here https://github.com/artefactual/archivematica/pull/1561

Connected to https://github.com/archivematica/Issues/issues/1071