### PR TITLE
Update browser and webdriver versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN groupadd --gid 333 archivematica \
 # Chrome
 #
 
-ARG CHROME_VERSION="google-chrome-beta"
+ARG CHROME_VERSION="google-chrome-stable"
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
 	&& echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
 	&& apt-get update -qqy \
@@ -66,7 +66,7 @@ RUN CD_VERSION=$(if [ ${CHROME_DRIVER_VERSION:-latest} = "latest" ]; then echo $
 # Firefox
 #
 
-ARG FIREFOX_VERSION=62.0.3
+ARG FIREFOX_VERSION=75.0
 RUN FIREFOX_DOWNLOAD_URL=$(if [ $FIREFOX_VERSION = "latest" ] || [ $FIREFOX_VERSION = "nightly-latest" ] || [ $FIREFOX_VERSION = "devedition-latest" ]; then echo "https://download.mozilla.org/?product=firefox-$FIREFOX_VERSION-ssl&os=linux64&lang=en-US"; else echo "https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2"; fi) \
 	&& apt-get update -qqy \
 	&& apt-get -qqy --no-install-recommends install firefox \
@@ -79,7 +79,7 @@ RUN FIREFOX_DOWNLOAD_URL=$(if [ $FIREFOX_VERSION = "latest" ] || [ $FIREFOX_VERS
 	&& mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
 	&& ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
 
-ARG GECKODRIVER_VERSION=0.23.0
+ARG GECKODRIVER_VERSION=0.26.0
 RUN GK_VERSION=$(if [ ${GECKODRIVER_VERSION:-latest} = "latest" ]; then echo $(wget -qO- "https://api.github.com/repos/mozilla/geckodriver/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([0-9.]+)".*/\1/'); else echo $GECKODRIVER_VERSION; fi) \
 	&& echo "Using GeckoDriver version: "$GK_VERSION \
 	&& wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GK_VERSION/geckodriver-v$GK_VERSION-linux64.tar.gz \


### PR DESCRIPTION
This PR updates the `CHROME_VERSION`, `FIREFOX_VERSION`, and `GECKODRIVER_VERSION` args in the Dockerfile to use the latest stable versions of Chrome, Firefox, and Geckodriver.

Running `make test-at-build && make test-at-check`, the tests now pass for both browsers:

```
Starting tests...
Chrome... success!
Capabilities: {'acceptInsecureCerts': False, 'browserName': 'chrome', 'browserVersion': '81.0.4044.138', 'chrome': {'chromedriverVersion': '81.0.4044.138 (8c6c7ba89cc9453625af54f11fd83179e23450fa-refs/branch-heads/4044@{#999})', 'userDataDir': '/tmp/.com.google.Chrome.1DnSru'}, 'goog:chromeOptions': {'debuggerAddress': 'localhost:36083'}, 'networkConnectionEnabled': False, 'pageLoadStrategy': 'normal', 'platformName': 'linux', 'proxy': {}, 'setWindowRect': True, 'strictFileInteractability': False, 'timeouts': {'implicit': 0, 'pageLoad': 300000, 'script': 30000}, 'unhandledPromptBehavior': 'dismiss and notify', 'webauthn:virtualAuthenticators': True}
Firefox... success!
Capabilities: {'acceptInsecureCerts': True, 'browserName': 'firefox', 'browserVersion': '75.0', 'moz:accessibilityChecks': False, 'moz:buildID': '20200403170909', 'moz:geckodriverVersion': '0.26.0', 'moz:headless': True, 'moz:processID': 96, 'moz:profile': '/tmp/rust_mozprofileazk0yC', 'moz:shutdownTimeout': 60000, 'moz:useNonSpecCompliantPointerOrigin': False, 'moz:webdriverClick': True, 'pageLoadStrategy': 'normal', 'platformName': 'linux', 'platformVersion': '5.3.0-7642-generic', 'rotatable': False, 'setWindowRect': True, 'strictFileInteractability': False, 'timeouts': {'implicit': 0, 'pageLoad': 300000, 'script': 30000}, 'unhandledPromptBehavior': 'dismiss and notify'}
```

Related to https://github.com/archivematica/Issues/issues/1199 and https://github.com/archivematica/Issues/issues/1206