### PR TITLE
Fix aip encryption tests

### DIFF
--- a/amuser/am_browser_ss_ability.py
+++ b/amuser/am_browser_ss_ability.py
@@ -118,6 +118,9 @@ class ArchivematicaBrowserStorageServiceAbility(
 
     def create_ss_space(self, attributes):
         """Create an AM SS Space using ``attributes``."""
+        if attributes.get("Access protocol") == "GPG encryption on Local Filesystem":
+            # Visiting this URL creates a default GPG key when there is none
+            self.navigate(self.get_gpg_keys_url())
         self.navigate(self.get_spaces_create_url())
         form_el = self.driver.find_element_by_css_selector(
             'form[action="/spaces/create/"]'
@@ -138,6 +141,10 @@ class ArchivematicaBrowserStorageServiceAbility(
                                     input_el.send_keys(val)
         self.driver.find_element_by_css_selector("input[type=submit]").click()
         self.wait_for_presence("div.alert-success", self.nihilistic_wait)
+        assert (
+            self.driver.find_element_by_css_selector("div.alert-success").text.strip()
+            == "Space saved."
+        )
         header = self.driver.find_element_by_tag_name("h1").text.strip()
         space_uuid = header.split()[0].replace('"', "").replace(":", "")
         return space_uuid


### PR DESCRIPTION
Running the AIP encrypt tests on a SS that has just been bootstrapped fails with:

```
  Scenario: Richard wants to create a space on his Archivematica Storage Service that encrypts all AIPs stored in that space. He also wants to confirm that the AIPs stored in that space are encrypted both by trying to open them without the key and by reading the AIP's pointer file. Finally, he wants to be able to download the AIPS via the Archivematica interface and have them be decrypted prior to download.  # features/core/aip-encryption.feature:29
    Given there is a standard GPG-encrypted space in the storage service                                                                                                                                                                                                                                                                                                                                                    # features/steps/aip_encryption_steps.py:35
    And there is a standard GPG-encrypted AIP Storage location in the storage service                                                                                                                                                                                                                                                                                                                                       # features/steps/aip_encryption_steps.py:47
      Assertion Failed: FAILED SUB-STEP: Given the user has ensured that there is a location in the GPG Space with attributes Purpose: AIP Storage; Relative path: var/archivematica/sharedDirectory/www/AIPsStoreEncrypted; Description: Store AIP Encrypted in standard Archivematica Directory (Create);
      Substep info: Traceback (most recent call last):
        File "/usr/local/lib/python3.6/dist-packages/behave/model.py", line 1329, in run
          match.run(runner.context)
        File "/usr/local/lib/python3.6/dist-packages/behave/matchers.py", line 98, in run
          self.func(context, *args, **kwargs)
        File "features/steps/aip_encryption_steps.py", line 112, in step_impl
          space_uuid, attributes
        File "/home/artefactual/acceptance-tests/amuser/am_browser_ss_ability.py", line 239, in ensure_ss_location_exists
          existing_locations = self.get_existing_locations(space_uuid)
        File "/home/artefactual/acceptance-tests/amuser/am_browser_ss_ability.py", line 217, in get_existing_locations
          loc_uuid_td_el = tr_el.find_element_by_xpath("td[position()=5]")
        File "/usr/local/lib/python3.6/dist-packages/selenium/webdriver/remote/webelement.py", line 351, in find_element_by_xpath
          return self.find_element(by=By.XPATH, value=xpath)
        File "/usr/local/lib/python3.6/dist-packages/selenium/webdriver/remote/webelement.py", line 654, in find_element
          {"using": by, "value": value})['value']
        File "/usr/local/lib/python3.6/dist-packages/selenium/webdriver/remote/webelement.py", line 628, in _execute
          return self._parent.execute(command, params)
        File "/usr/local/lib/python3.6/dist-packages/selenium/webdriver/remote/webdriver.py", line 320, in execute
          self.error_handler.check_response(response)
        File "/usr/local/lib/python3.6/dist-packages/selenium/webdriver/remote/errorhandler.py", line 242, in check_response
          raise exception_class(message, screen, stacktrace)
      selenium.common.exceptions.NoSuchElementException: Message: Unable to locate element: td[position()=5]
```

Even though it seems like the `there is a standard GPG-encrypted AIP Storage location in the storage service` step raises the error, there are two problems with the previous `there is a standard GPG-encrypted space in the storage service` step:

1. The form submission when the space is created fails but there is no code to assert/catch that.
2. At that point there are no GPG keys in the system yet which is the cause of the form submission error.

I think this hasn't shown in Jenkins because the ansible playbooks create the default key, but you can see it in a docker based AMAUAT workflow in GitHub:

![Screenshot_2021-02-22 artefactual archivematica](https://user-images.githubusercontent.com/560781/108789529-13793780-7540-11eb-8008-1a1aa35b494a.png)

This updates the helper function to create spaces to visit the `/administration/keys/` view when it's a GPG space which [generates a default key if one doesn't exist](https://github.com/artefactual/archivematica-storage-service/blob/ab294f9a92827d5c4080d0c8123e3ee71a62d16a/storage_service/common/gpgutils.py#L106-L107) and adds an assertion that checks for the successful creation message before continuing.

Connected to https://github.com/archivematica/Issues/issues/1317