### PR TITLE
Fix @ipc and @icc tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ reports/
 data/
 *.log
 *~
+*.py[co]

--- a/amuser/am_browser_ability.py
+++ b/amuser/am_browser_ability.py
@@ -98,6 +98,7 @@ class ArchivematicaBrowserAbility(
                 self.driver.find_element_by_css_selector('select[title="query type"]')
             ).select_by_visible_text("Phrase")
             self.driver.find_element_by_id("search_submit").click()
+            self.wait_for_presence("#archival-storage-entries_info")
             summary_el = self.driver.find_element_by_id("archival-storage-entries_info")
             if summary_el.text.strip() == "Showing 0 to 0 of 0 entries":
                 attempts += 1
@@ -155,7 +156,7 @@ class ArchivematicaBrowserAbility(
             r = s.get(url)
             if r.status_code == requests.codes.ok:
                 logger.info(
-                    "Requests got OK status code %s when requesting" " %s",
+                    "Requests got OK status code %s when requesting %s",
                     r.status_code,
                     url,
                 )
@@ -223,6 +224,7 @@ class ArchivematicaBrowserAbility(
                 self.driver.find_element_by_css_selector('select[title="query type"]')
             ).select_by_visible_text("Phrase")
             self.driver.find_element_by_id("search_submit").click()
+            self.wait_for_presence("#backlog-entries_info")
             summary_el = self.driver.find_element_by_id("backlog-entries_info")
             if summary_el.text.strip() == "Showing 0 to 0 of 0 entries":
                 seconds += 1
@@ -564,6 +566,6 @@ def _get_decision_id_from_label(decision_label):
                 break
     if decision_id is None:
         raise ArchivematicaBrowserAbilityError(
-            "Unable to determine a decision id given input" " parameters"
+            "Unable to determine a decision id given input parameters"
         )
     return decision_id

--- a/amuser/am_browser_file_explorer_ability.py
+++ b/amuser/am_browser_file_explorer_ability.py
@@ -66,7 +66,7 @@ class ArchivematicaBrowserFileExplorerAbility(
                 self.click_transfer_directory_tries
                 >= self.max_click_transfer_directory_attempts
             ):
-                logger.warning("Failed to navigate to transfer directory" " %s", path)
+                logger.warning("Failed to navigate to transfer directory %s", path)
                 self.click_transfer_directory_tries = 0
                 raise
             else:

--- a/amuser/am_mets_ability.py
+++ b/amuser/am_mets_ability.py
@@ -61,7 +61,7 @@ class ArchivematicaMETSAbility(base.Base):
             # All entities have an id, i.e., DMDID or ADMID
             assert entity.get(
                 "id"
-            ), "Unable to find a DMDID/ADMID for entity" " {}".format(entity["path"])
+            ), "Unable to find a DMDID/ADMID for entity {}".format(entity["path"])
             purls = []
             # All entities should have the following types of identifier
             for idfr_type in ("UUID", "hdl", "URI"):
@@ -74,7 +74,7 @@ class ArchivematicaMETSAbility(base.Base):
                     " {}".format(idfr_type, entity["path"])
                 )
                 if idfr_type == "UUID":
-                    assert utils.is_uuid(idfr), "Identifier {} is not a" " UUID".format(
+                    assert utils.is_uuid(idfr), "Identifier {} is not a UUID".format(
                         idfr
                     )
                 elif idfr_type == "hdl":
@@ -119,8 +119,7 @@ class ArchivematicaMETSAbility(base.Base):
         assert dmd_sec_el is not None
         identifiers = []
         for obj_idfr_el in dmd_sec_el.findall(
-            "mets:mdWrap/" "mets:xmlData/" "premis:object/" "premis:objectIdentifier",
-            ns,
+            "mets:mdWrap/mets:xmlData/premis:object/premis:objectIdentifier", ns
         ):
             identifiers.append(
                 (
@@ -166,8 +165,7 @@ def _add_entity_identifiers(entity, doc, ns):
     else:
         dmd_sec_el = doc.xpath("mets:dmdSec[@ID='{}']".format(e_id), namespaces=ns)[0]
         for obj_idfr_el in dmd_sec_el.findall(
-            "mets:mdWrap/" "mets:xmlData/" "premis:object/" "premis:objectIdentifier",
-            ns,
+            "mets:mdWrap/mets:xmlData/premis:object/premis:objectIdentifier", ns
         ):
             identifiers.append(
                 (

--- a/amuser/am_ssh_ability.py
+++ b/amuser/am_ssh_ability.py
@@ -86,7 +86,7 @@ class ArchivematicaSSHAbility(base.Base):
         directory.
         """
         if not self.ssh_accessible:
-            logger.info("You do not have SSH access to the Archivematica" " server")
+            logger.info("You do not have SSH access to the Archivematica server")
             return None
         if server_dir_path[-1] == "/":
             server_dir_path = server_dir_path[:-1]
@@ -141,7 +141,7 @@ class ArchivematicaSSHAbility(base.Base):
         and expecting to find no file at /etc/init.d/elasticsearch.
         """
         if not self.ssh_accessible:
-            logger.info("You do not have SSH access to the Archivematica" " server")
+            logger.info("You do not have SSH access to the Archivematica server")
             return None
         if self.server_user and self.ssh_identity_file:
             cmd = (

--- a/amuser/amuser.py
+++ b/amuser/amuser.py
@@ -51,7 +51,7 @@ class ArchivematicaUser(base.Base):
             fname, extension = os.path.splitext(fname)
         if extension != ".7z":
             logger.info(
-                "decompress_package; extension %s of fname %s is NOT" " .7z",
+                "decompress_package; extension %s of fname %s is NOT .7z",
                 extension,
                 fname,
             )
@@ -67,7 +67,7 @@ class ArchivematicaUser(base.Base):
             )
         except subprocess.CalledProcessError:
             logger.info(
-                "7z extraction failed. File %s is not a .7z file or it" " is encrypted",
+                "7z extraction failed. File %s is not a .7z file or it is encrypted",
                 package_path,
             )
             return None

--- a/amuser/selenium_ability.py
+++ b/amuser/selenium_ability.py
@@ -113,7 +113,7 @@ class ArchivematicaSeleniumAbility(base.Base):
 
         def window_handles_count_has_changed(driver):
             logger.info(
-                "Previously we had %s window handles, now we have" " %s",
+                "Previously we had %s window handles, now we have %s",
                 len(handles_before),
                 len(driver.window_handles),
             )

--- a/amuser/utils.py
+++ b/amuser/utils.py
@@ -34,8 +34,7 @@ def is_hdl(idfr, entity_type, accession_no=None):
         _, pid = idfr.split("/")
     except ValueError:
         logger.info(
-            "Unable to get exactly two values by splitting %s on a forward" " slash",
-            idfr,
+            "Unable to get exactly two values by splitting %s on a forward slash", idfr
         )
         return False
     if accession_no and entity_type == "aip":

--- a/features/environment.py
+++ b/features/environment.py
@@ -192,7 +192,7 @@ def after_scenario(context, scenario):
     # In the following scenario, we've created a weird FPR rule. Here we put
     # things back as they were: make access .mov files normalize to .mp4
     if scenario.name == (
-        "Isla wants to confirm that normalization to .mkv for" " access is successful"
+        "Isla wants to confirm that normalization to .mkv for access is successful"
     ):
         context.am_user.browser.change_normalization_rule_command(
             "Access Generic MOV", "Transcoding to mp4 with ffmpeg"

--- a/features/steps/aip_encryption_steps.py
+++ b/features/steps/aip_encryption_steps.py
@@ -72,9 +72,7 @@ def step_impl(context):
     )
 
 
-@given(
-    "there is a standard GPG-encrypted Replicator location in the storage" " service"
-)
+@given("there is a standard GPG-encrypted Replicator location in the storage service")
 def step_impl(context):
     context.execute_steps(
         "Given the user has ensured that there is a location in the GPG Space with"
@@ -210,7 +208,7 @@ def step_impl(context):
         )
 
 
-@when("the user assigns a different GPG key to the standard GPG-encrypted" " space")
+@when("the user assigns a different GPG key to the standard GPG-encrypted space")
 def step_impl(context):
     """Edit the standard GPG-encrypted space so that it is using a GPG key
     other than the one stored in ``context.scenario.new_key_name``.
@@ -314,7 +312,7 @@ def step_impl(context, aip_description, second_aip_description, event_type):
         assert event_uuid == premis_related_event_uuid
 
 
-@then("the {aip_description} pointer file contains a(n) {event_type}" " PREMIS:EVENT")
+@then("the {aip_description} pointer file contains a(n) {event_type} PREMIS:EVENT")
 def step_impl(context, aip_description, event_type):
     aip_ptr_attr = utils.aip_descr_to_ptr_attr(aip_description)
     pointer_path = getattr(context.scenario, aip_ptr_attr)

--- a/features/steps/indexless_steps.py
+++ b/features/steps/indexless_steps.py
@@ -163,7 +163,7 @@ def step_impl(context):
     es_indexing_config_text = context.am_user.browser.get_es_indexing_config_text()
     assert es_indexing_config_text is not None
     assert es_indexing_config_text.strip() == (
-        "Elasticsearch indexing has been disabled in this Archivematica" " installation"
+        "Elasticsearch indexing has been disabled in this Archivematica installation"
     )
 
 
@@ -257,7 +257,7 @@ def step_impl(context):
             rel_path,
         )
         logger.info(
-            "Relative path %s in the indexless AIP matches %s in" " the indexed one",
+            "Relative path %s in the indexless AIP matches %s in the indexed one",
             rel_path,
             counterpart,
         )
@@ -293,7 +293,7 @@ def step_impl(context, tab_name):
     assert tab_name not in displayed_tabs
 
 
-@then("a warning is displayed indicating that the {tab_name} is not" " operational")
+@then("a warning is displayed indicating that the {tab_name} is not operational")
 def step_impl(context, tab_name):
     tab_name = tab_name.replace(" tab", "").strip().lower()
     msg1 = "Elasticsearch Indexing Disabled"
@@ -366,7 +366,7 @@ def _get_rel_paths(path):
 
 
 uuid_pattern = re.compile(
-    "[a-f0-9]{8}-" "[a-f0-9]{4}-" "[a-f0-9]{4}-" "[a-f0-9]{4}-" "[a-f0-9]{12}"
+    "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
 )
 
 

--- a/features/steps/manual_normalization_steps.py
+++ b/features/steps/manual_normalization_steps.py
@@ -72,7 +72,7 @@ def step_impl(context, transfer_path):
 @then("all preservation tasks recognize the manually normalized derivatives")
 def step_impl(context):
     skipping_msg = (
-        "is file group usage manualNormalization instead of" "  original  - skipping"
+        "is file group usage manualNormalization instead of original  - skipping"
     )
     already_nmlzd_msg = "was already manually normalized into"
     for task in context.scenario.job["tasks"].values():

--- a/features/steps/mediaconch_steps.py
+++ b/features/steps/mediaconch_steps.py
@@ -28,7 +28,7 @@ POLICIES_DIR = "etc/mediaconch-policies"
 # ------------------------------------------------------------------------------
 
 
-@given("directory {transfer_path} contains files that are all {file_validity}" " .mkv")
+@given("directory {transfer_path} contains files that are all {file_validity} .mkv")
 def step_impl(context, transfer_path, file_validity):
     pass
 
@@ -89,6 +89,7 @@ def step_impl(context):
 def step_impl(context):
     context.execute_steps(
         "Given a base processing configuration for MediaConch tests\n"
+        "And the user enables the preservation normalization rules for video files\n"
         'And the processing config decision "Perform policy checks on preservation derivatives" is set to "Yes"\n'
         'And the processing config decision "Normalize" is set to "Normalize for preservation"\n'
         'And the processing config decision "Store AIP" is set to "Yes"'
@@ -99,6 +100,7 @@ def step_impl(context):
 def step_impl(context):
     context.execute_steps(
         "Given a base processing configuration for MediaConch tests\n"
+        "And the user enables the preservation normalization rules for video files\n"
         'And the processing config decision "Approve normalization" is set to "None"\n'
         'And the processing config decision "Normalize" is set to "Normalize for preservation"'
     )
@@ -124,7 +126,7 @@ def step_impl(context, transfer_path):
     """
 
 
-@given("a processing configuration for conformance checks on access" " derivatives")
+@given("a processing configuration for conformance checks on access derivatives")
 def step_impl(context):
     context.execute_steps(
         "Given a base processing configuration for MediaConch tests\n"
@@ -202,6 +204,18 @@ def step_impl(context, purpose, format_, command):
     context.am_user.browser.ensure_fpr_rule(purpose, format_, command)
 
 
+@given("the user enables the preservation normalization rules for video files")
+def step_impl(context):
+    # There are many more disabled rules but only these are needed by the sample data
+    formats = ["Generic MKV", "Generic MOV", "MPEG-4 Video"]
+    for format_ in formats:
+        context.am_user.browser.ensure_fpr_rule_enabled(
+            "Preservation",
+            "Video:{}:{}".format(format_, format_),
+            "Transcoding to mkv with ffmpeg",
+        )
+
+
 # Whens
 # ------------------------------------------------------------------------------
 
@@ -226,7 +240,7 @@ def step_impl(context, policy_file):
     context.am_user.browser.upload_policy(policy_path)
 
 
-@when("the user ensures there is an FPR command that uses policy file" " {policy_file}")
+@when("the user ensures there is an FPR command that uses policy file {policy_file}")
 def step_impl(context, policy_file):
     policy_path = get_policy_path(policy_file)
     context.am_user.browser.ensure_fpr_policy_check_command(policy_file, policy_path)
@@ -397,16 +411,14 @@ def step_impl(context, policy_file):
             assert doc.getroot().tag == "{https://mediaarea.net/mediaconch}MediaConch"
 
 
-@then(
-    "validate preservation derivatives micro-service output is" " {microservice_output}"
-)
+@then("validate preservation derivatives micro-service output is {microservice_output}")
 def step_impl(context, microservice_output):
     utils.ingest_ms_output_is(
         "Validate preservation derivatives", microservice_output, context
     )
 
 
-@then("validate access derivatives micro-service output is" " {microservice_output}")
+@then("validate access derivatives micro-service output is {microservice_output}")
 def step_impl(context, microservice_output):
     utils.ingest_ms_output_is(
         "Validate access derivatives", microservice_output, context

--- a/features/steps/mets_steps.py
+++ b/features/steps/mets_steps.py
@@ -44,7 +44,7 @@ def step_impl(context, count, event_type, properties):
     )
 
 
-@then("in the METS file there are/is {count} PREMIS event(s) of type" " {event_type}")
+@then("in the METS file there are/is {count} PREMIS event(s) of type {event_type}")
 def step_impl(context, count, event_type):
     mets = utils.get_mets_from_scenario(context)
     events = []
@@ -87,9 +87,7 @@ def step_impl(context, conj_quant):
     # del context.scenario.mets
 
 
-@then(
-    "in the METS file the metsHdr element has {quant} dmdSec next sibling" " element(s)"
-)
+@then("in the METS file the metsHdr element has {quant} dmdSec next sibling element(s)")
 def step_impl(context, quant):
     mets = utils.get_mets_from_scenario(context, api=True)
     mets_dmd_sec_els = mets.findall(".//mets:dmdSec", context.am_user.mets.mets_nsmap)

--- a/features/steps/performance_stdout_no_write_steps.py
+++ b/features/steps/performance_stdout_no_write_steps.py
@@ -145,7 +145,7 @@ def step_impl(context, filename):
     pass
 
 
-@then("there is non-zero stdout and stderr for the client scripts in" " {filename}")
+@then("there is non-zero stdout and stderr for the client scripts in {filename}")
 def step_impl(context, filename):
     pass
 

--- a/features/steps/uuids_for_directories_steps.py
+++ b/features/steps/uuids_for_directories_steps.py
@@ -193,9 +193,7 @@ def step_impl(context):
                 )
 
 
-@then(
-    "the UUIDs for the subfolders and digital objects are written to the METS" " file"
-)
+@then("the UUIDs for the subfolders and digital objects are written to the METS file")
 def step_impl(context):
     """Make the following assertions:
     - All directories are listed in the logical (Normative Directory Structure)


### PR DESCRIPTION
This fixes the preservation scenarios of the `ingest-policy-check` and
`ingest-mk-conformance` features by enabling some of the video
normalization FPR rules that [were disabled in Archivematica 1.11](https://github.com/archivematica/Issues/issues/912)
because they produce file copies too large.

The `ensure_fpr_rule_enabled` helper function is now complete and can
enable disabled rules, and some wait checks have been introduced for
interactions with DataTable related elements.

Connected to https://github.com/archivematica/Issues/issues/1115