### PR TITLE
Specify the job to virus scan in directories

### DIFF
--- a/features/black_box/virus.feature
+++ b/features/black_box/virus.feature
@@ -1,13 +1,14 @@
 @black-box
 Feature: Alma wants to ensure that virus scanning in Archivematica works correctly to ensure transfers pass when they have no viruses, and transfers fail when they contain viruses.
-
   Scenario: Virus checks for a transfer pass
     Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV"
     When the transfer compliance is verified
-    Then the "Scan for viruses" job completes successfully
+    Then the "Scan for viruses in directories" job completes successfully
 
   Scenario: Virus checks for a transfer fail
     Given a "standard" transfer type located in "TestTransfers/virusTests"
     When the transfer compliance is verified
-    Then the "Scan for viruses" job fails
+    Then the "Scan for viruses in directories" job fails
     And the "Failed transfer" microservice is executed
+
+

--- a/features/black_box/virus.feature
+++ b/features/black_box/virus.feature
@@ -1,5 +1,6 @@
 @black-box
 Feature: Alma wants to ensure that virus scanning in Archivematica works correctly to ensure transfers pass when they have no viruses, and transfers fail when they contain viruses.
+
   Scenario: Virus checks for a transfer pass
     Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV"
     When the transfer compliance is verified
@@ -10,5 +11,3 @@ Feature: Alma wants to ensure that virus scanning in Archivematica works correct
     When the transfer compliance is verified
     Then the "Scan for viruses in directories" job fails
     And the "Failed transfer" microservice is executed
-
-


### PR DESCRIPTION
Change virus feature to respect the changes made in the processing config. 
Testing is supposed to look for a job called virus scan in directories now.

