### PR TITLE
Make uuids-dirs tag to extract to a temp directory

### DIFF
--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -285,7 +285,7 @@ def get_duration_as_float(duration_string):
 
 
 def unzip(zip_path):
-    directory_to_extract_to = os.path.dirname(zip_path)
+    directory_to_extract_to = tempfile.mkdtemp()
     zip_ref = zipfile.ZipFile(zip_path, "r")
     try:
         zip_ref.extractall(directory_to_extract_to)

--- a/features/steps/uuids_for_directories_steps.py
+++ b/features/steps/uuids_for_directories_steps.py
@@ -180,16 +180,16 @@ def step_impl(context):
             ):
                 continue
             assert dirpath in subpaths, (
-                "Expected directory path\n{}\nis not in METS structmap"
-                " paths\n{}".format(dirpath, pprint.pformat(subpaths))
+                "Expected directory path\n{}\nis not in METS {}-type structmap"
+                " paths\n{}".format(dirpath, type_, pprint.pformat(subpaths))
             )
-        if type == "physical":
+        if type_ == "physical":
             for filepath in context.scenario.remote_dir_files:
                 if os.path.basename(filepath) == ".gitignore":
                     continue
                 assert filepath in subpaths, (
-                    "Expected file path\n{}\nis not in METS structmap"
-                    " paths\n{}".format(filepath, pprint.pformat(subpaths))
+                    "Expected file path\n{}\nis not in METS {}-type structmap"
+                    " paths\n{}".format(filepath, type_, pprint.pformat(subpaths))
                 )
 
 
@@ -225,7 +225,9 @@ def step_impl(context):
             )
             assert (
                 mets_div_el is not None
-            ), "Could not find a <mets:div> for directory at {}".format(dirpath)
+            ), "Could not find a <mets:div> for directory at {} in {}-type structmap".format(
+                dirpath, type_
+            )
             if (
                 type_ == "logical"
                 and dirpath not in context.scenario.remote_dir_empty_subfolders
@@ -235,7 +237,9 @@ def step_impl(context):
             dmdSec_el = mets.find('.//mets:dmdSec[@ID="{}"]'.format(dmdid), ns)
             assert (
                 dmdSec_el is not None
-            ), "Could not find a <mets:dmdSec> for directory at {}".format(dirpath)
+            ), "Could not find a <mets:dmdSec> for directory at {} in {}-type structmap".format(
+                dirpath, type_
+            )
             try:
                 id_type = dmdSec_el.find(
                     ".//premis:objectIdentifierType", ns


### PR DESCRIPTION
The uuids-dirs tag tries to extract the zipped bag test case to the
sample data directory. If the file system is readonly (like in the
compose dev environment) this fails and the rest of the steps lose
track of the files and directories relevant to the transfer.

This fixes it by extracting to a temporary directory instead.

Connected to https://github.com/archivematica/Issues/issues/1177