### PR TITLE
Set the locale in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get -qqy update \
 		wget \
 		git \
 		build-essential \
+		locales \
 		openssh-client \
 		p7zip-full \
 		python \
@@ -29,6 +30,13 @@ RUN apt-get -qqy update \
 		libxslt-dev \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+
+# Set the locale
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 ENV TZ "UTC"
 RUN echo "${TZ}" > /etc/timezone \

--- a/README.rst
+++ b/README.rst
@@ -304,7 +304,7 @@ Timeouts and attempt counters
 At various points, these tests wait for fixed periods of time or attempt to
 perform some action a fixed number of times before giving up the attempt. The
 variables holding these *wait* and *attempt* values are listed with their
-defaults in `features/environment.py <features/environment.py`_, e.g.,
+defaults in `features/environment.py <features/environment.py>`_, e.g.,
 ``MAX_DOWNLOAD_AIP_ATTEMPTS``. If you find that tests are failing because of
 timeouts being exceeded, or conversely that tests that should be failing are
 waiting too long for an event that will never happen, you can modify these


### PR DESCRIPTION
While preparing a few test transfers with non ascii paths I realized that if a feature file includes non ascii text the `make test-at-behave` rule of the development environment currently fails like this:

```
    Given a "standard" transfer type located in "Exception UnicodeEncodeError: 'ascii' codec can't encode characters in position 23-28: ordinal not in range(128)
Traceback (most recent call last):
  File "/usr/local/bin/behave", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/dist-packages/behave/__main__.py", line 183, in main
    return run_behave(config)
  File "/usr/local/lib/python3.6/dist-packages/behave/__main__.py", line 127, in run_behave
    failed = runner.run()
  File "/usr/local/lib/python3.6/dist-packages/behave/runner.py", line 804, in run
    return self.run_with_paths()
  File "/usr/local/lib/python3.6/dist-packages/behave/runner.py", line 824, in run_with_paths
    return self.run_model()
  File "/usr/local/lib/python3.6/dist-packages/behave/runner.py", line 626, in run_model
    failed = feature.run(self)
  File "/usr/local/lib/python3.6/dist-packages/behave/model.py", line 321, in run
    failed = scenario.run(runner)
  File "/usr/local/lib/python3.6/dist-packages/behave/model.py", line 1114, in run
    failed = scenario.run(runner)
  File "/usr/local/lib/python3.6/dist-packages/behave/model.py", line 711, in run
    if not step.run(runner):
  File "/usr/local/lib/python3.6/dist-packages/behave/model.py", line 1311, in run
    formatter.match(match)
  File "/usr/local/lib/python3.6/dist-packages/behave/formatter/pretty.py", line 132, in match
    self._match.location, self.monochrome)
  File "/usr/local/lib/python3.6/dist-packages/behave/formatter/pretty.py", line 301, in print_step
    self.stream.write(arg_format.text(arg.original))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 23-28: ordinal not in range(128)
```

This fixes it by installing the `locales` package and generating the `en_US.UTF-8` locale in the Docker image which is the [same approach we use in the `hack/Dockerfile`](https://github.com/artefactual/archivematica/blob/b9d2d944cf820927d1df7f9d513aba06ef5071a8/hack/Dockerfile#L20-L24).

Connected to https://github.com/archivematica/Issues/issues/1317