### PR TITLE
Add wait after searching the transfer backlog

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -361,6 +361,7 @@ def step_impl(context, aip_description):
 def step_impl(context):
     uuid_val = utils.get_uuid_val(context, "transfer")
     context.am_user.browser.wait_for_dip_in_transfer_backlog(uuid_val)
+    time.sleep(context.am_user.pessimistic_wait)
 
 
 @when("the user adds metadata")


### PR DESCRIPTION
This fixes a problem in the [`@transfer-backlog` tag](https://github.com/artefactual-labs/archivematica-acceptance-tests/blob/fed8e1f8edaec6623e99f0534590dea4f8e4cea6/features/core/aip-encryption.feature#L65-L66) when the test validates that the `tar` file is encrypted before the Storage Service has created it.

Connected to https://github.com/archivematica/Issues/issues/1317