### PR TITLE
Retry downloading the METS from the API

### DIFF
--- a/amuser/am_browser_ingest_ability.py
+++ b/amuser/am_browser_ingest_ability.py
@@ -16,6 +16,7 @@ from selenium.common.exceptions import (
     NoSuchElementException,
     TimeoutException,
 )
+import tenacity
 
 from amclient import AMClient
 
@@ -66,6 +67,7 @@ class ArchivematicaBrowserIngestAbility(selenium_ability.ArchivematicaSeleniumAb
         logger.info("Got SIP UUID %s", sip_uuid)
         return sip_uuid
 
+    @tenacity.retry(stop=tenacity.stop_after_attempt(20), wait=tenacity.wait_fixed(15))
     def get_mets_via_api(self, transfer_name, sip_uuid=None, parse_xml=True):
         """Return METS once stored in an AIP."""
         if not sip_uuid:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,8 @@
-git+https://github.com/artefactual-labs/amclient@e779e45a0d31e1c576cd9279d792fec59a62c20f#egg=amclient
+amclient==1.1.1
 behave>=1.0
 lxml
 metsrw
 pexpect
 requests<3.0
+tenacity==7.0.0
 selenium==3.14.0


### PR DESCRIPTION
This fixes an issue when some steps try to download the METS file of
an AIP before the Storage Service has finished storing it. It adds
retries by using the `tenacity` package.

It also updates the `amclient` package to a released version.

Connected to https://github.com/archivematica/Issues/issues/1452