### PR TITLE
Update firefox and selenium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN CD_VERSION=$(if [ ${CHROME_DRIVER_VERSION:-latest} = "latest" ]; then echo $
 # Firefox
 #
 
-ARG FIREFOX_VERSION=75.0
+ARG FIREFOX_VERSION=89.0.2
 RUN FIREFOX_DOWNLOAD_URL=$(if [ $FIREFOX_VERSION = "latest" ] || [ $FIREFOX_VERSION = "nightly-latest" ] || [ $FIREFOX_VERSION = "devedition-latest" ]; then echo "https://download.mozilla.org/?product=firefox-$FIREFOX_VERSION-ssl&os=linux64&lang=en-US"; else echo "https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2"; fi) \
 	&& apt-get update -qqy \
 	&& apt-get -qqy --no-install-recommends install firefox \

--- a/amuser/am_browser_preservation_planning_ability.py
+++ b/amuser/am_browser_preservation_planning_ability.py
@@ -41,7 +41,7 @@ class ArchivematicaBrowserPreservationPlanningAbility(
                 break
 
     def wait_for_rule_edit_interface(self):
-        self.wait_for_presence("#id_f-purpose")
+        self.wait_for_presence("input[type=submit]")
 
     def set_fpr_command(self, command_name):
         command_select_el = self.driver.find_element_by_id("id_f-command")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,4 +5,4 @@ metsrw
 pexpect
 requests<3.0
 tenacity==7.0.0
-selenium==3.14.0
+selenium==3.141.0


### PR DESCRIPTION
This also fixes an issue discovered in Jenkins where the FPR form for editing rules takes a long time to load and the wait selector uses an inadequate element for pausing execution.