### PR TITLE
Add black-box scenarios for partial reingests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN CD_VERSION=$(if [ ${CHROME_DRIVER_VERSION:-latest} = "latest" ]; then echo $
 # Firefox
 #
 
-ARG FIREFOX_VERSION=89.0.2
+ARG FIREFOX_VERSION=94.0.2
 RUN FIREFOX_DOWNLOAD_URL=$(if [ $FIREFOX_VERSION = "latest" ] || [ $FIREFOX_VERSION = "nightly-latest" ] || [ $FIREFOX_VERSION = "devedition-latest" ]; then echo "https://download.mozilla.org/?product=firefox-$FIREFOX_VERSION-ssl&os=linux64&lang=en-US"; else echo "https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2"; fi) \
 	&& apt-get update -qqy \
 	&& apt-get -qqy --no-install-recommends install firefox \
@@ -87,7 +87,7 @@ RUN FIREFOX_DOWNLOAD_URL=$(if [ $FIREFOX_VERSION = "latest" ] || [ $FIREFOX_VERS
 	&& mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
 	&& ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
 
-ARG GECKODRIVER_VERSION=0.26.0
+ARG GECKODRIVER_VERSION=0.30.0
 RUN GK_VERSION=$(if [ ${GECKODRIVER_VERSION:-latest} = "latest" ]; then echo $(wget -qO- "https://api.github.com/repos/mozilla/geckodriver/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([0-9.]+)".*/\1/'); else echo $GECKODRIVER_VERSION; fi) \
 	&& echo "Using GeckoDriver version: "$GK_VERSION \
 	&& wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GK_VERSION/geckodriver-v$GK_VERSION-linux64.tar.gz \

--- a/amuser/am_browser_ability.py
+++ b/amuser/am_browser_ability.py
@@ -307,6 +307,9 @@ class ArchivematicaBrowserAbility(
     # Processing Configuration
     # =========================================================================
 
+    def reset_default_processing_config(self):
+        self.navigate(self.get_reset_default_processing_config_url())
+
     def save_default_processing_config(self):
         """Click the "Save" button in the default processing config edit
         interface.

--- a/amuser/urls.py
+++ b/amuser/urls.py
@@ -14,6 +14,10 @@ AM_URLS = (
         "get_edit_default_processing_config_url",
         "{}administration/processing/edit/default/",
     ),
+    (
+        "get_reset_default_processing_config_url",
+        "{}administration/processing/reset/default/",
+    ),
     ("get_handle_config_url", "{}administration/handle/"),
     ("get_ingest_url", "{}ingest/"),
     ("get_installer_welcome_url", "{}installer/welcome/"),

--- a/features/black_box/reingest-aip.feature
+++ b/features/black_box/reingest-aip.feature
@@ -21,3 +21,28 @@ Feature: Alma wants to be able to re-ingest an AIP and have the reingest recorde
     And there is a fileSec for deleted files for objects that were re-normalized
     And there is a current and a superseded techMD for each original object
     And there is a sourceMD containing a BagIt mdWrap in the reingested AIP METS
+
+  Scenario: Metadata only reingest without error
+    Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV"
+    And a processing configuration for metadata only reingests
+    When a "METADATA" reingest is started using the "default" processing configuration
+    And the "SampleTransfers/MetadataOnlyReingest/metadata.csv" metadata file is added
+    And the reingest is approved
+    And the reingest has been processed
+    Then the AIP can be successfully stored
+    And the "Reingest AIP" ingest microservice completes successfully
+    And there is a reingestion event for each original object in the AIP METS
+    And the "metadata.csv" file is in the reingest metadata directory
+    And every file in the reingested metadata.csv file has two dmdSecs with the original and updated metadata
+
+  Scenario: Partial reingest without error
+    Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV"
+    And a processing configuration for partial reingests
+    When a "OBJECTS" reingest is started using the "default" processing configuration
+    And the reingest is approved
+    And the reingest has been processed
+    Then the AIP can be successfully stored
+    And the "Reingest AIP" ingest microservice completes successfully
+    And there is a reingestion event for each original object in the AIP METS
+    And the DIP is downloaded
+    And the DIP contains access copies for each original object in the transfer

--- a/features/black_box/reingest-aip.feature
+++ b/features/black_box/reingest-aip.feature
@@ -2,16 +2,20 @@
 Feature: Alma wants to be able to re-ingest an AIP and have the reingest recorded accurately in the AIP METS file.
 
   Scenario: Reingest without error
-    Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV" has been reingested
-    When the reingest has been processed
+    Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV"
+    When a "FULL" reingest is started using the "automated" processing configuration
+    And the reingest is approved
+    And the reingest has been processed
     Then the AIP can be successfully stored
     And there is a reingestion event for each original object in the AIP METS
     And there is a fileSec for deleted files for objects that were re-normalized
     And there is a current and a superseded techMD for each original object
 
-Scenario: Reingest unzipped bag transfer
-    Given a "unzipped bag" transfer type located in "SampleTransfers/UnzippedBag" has been reingested
-    When the reingest has been processed
+  Scenario: Reingest unzipped bag transfer
+    Given a "unzipped bag" transfer type located in "SampleTransfers/UnzippedBag"
+    When a "FULL" reingest is started using the "automated" processing configuration
+    And the reingest is approved
+    And the reingest has been processed
     Then the AIP can be successfully stored
     And there is a reingestion event for each original object in the AIP METS
     And there is a fileSec for deleted files for objects that were re-normalized

--- a/features/environment.py
+++ b/features/environment.py
@@ -22,7 +22,6 @@ class EnvironmentError(Exception):
 ROOT_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Archivematica sample-data paths.
 sample_data_path = os.path.join("archivematica", "archivematica-sampledata")
-transfers_cache = {}
 
 # Change these to match your test environment
 # These may also be overridden as Behave userdata options

--- a/features/steps/black_box_steps.py
+++ b/features/steps/black_box_steps.py
@@ -49,19 +49,28 @@ def step_impl(context, transfer_type, sample_transfer_path):
     context.current_transfer = transfer
 
 
-@given(
-    'a "{transfer_type}" transfer type located in "{sample_transfer_path}" has been reingested'
+@when(
+    'a "{reingest_type}" reingest is started using the "{processing_config}" processing configuration'
 )
-def step_impl(context, transfer_type, sample_transfer_path):
-    context.execute_steps(
-        'Given a "{}" transfer type located in "{}"\n'.format(
-            transfer_type, sample_transfer_path
-        )
-    )
+def step_impl(context, reingest_type, processing_config):
     reingest = utils.create_reingest(
-        context.api_clients_config, context.current_transfer
+        context.api_clients_config,
+        context.current_transfer,
+        reingest_type,
+        processing_config,
     )
     context.current_transfer.update(reingest)
+
+
+@when("the reingest is approved")
+def step_impl(context):
+    if context.current_transfer["reingest_type"] == "FULL":
+        approve_handler = utils.approve_transfer
+    else:
+        approve_handler = utils.approve_partial_reingest
+    approve_handler(
+        context.api_clients_config, context.current_transfer["reingest_uuid"]
+    )
 
 
 @when("the AIP is downloaded")
@@ -89,6 +98,13 @@ def step_impl(context):
 
 @when("the reingest has been processed")
 def step_impl(context):
+    context.current_transfer.update(
+        utils.finish_reingest(
+            context.api_clients_config,
+            context.current_transfer["reingest_type"],
+            context.current_transfer["reingest_uuid"],
+        )
+    )
     utils.is_valid_download(context.current_transfer["aip_mets_location"])
     utils.is_valid_download(context.current_transfer["reingest_aip_mets_location"])
 

--- a/features/steps/black_box_steps.py
+++ b/features/steps/black_box_steps.py
@@ -49,6 +49,27 @@ def step_impl(context, transfer_type, sample_transfer_path):
     context.current_transfer = transfer
 
 
+@given("a processing configuration for metadata only reingests")
+def step_impl(context):
+    context.am_user.browser.reset_default_processing_config()
+    context.am_user.browser.set_processing_config_decision(
+        decision_label="Normalize", choice_value="Do not normalize"
+    )
+    context.am_user.browser.set_processing_config_decision(
+        decision_label="Reminder: add metadata if desired", choice_value="Continue"
+    )
+    context.am_user.browser.set_processing_config_decision(
+        decision_label="Transcribe files (OCR)", choice_value="No"
+    )
+    context.am_user.browser.set_processing_config_decision(
+        decision_label="Store AIP", choice_value="Yes"
+    )
+    context.am_user.browser.set_processing_config_decision(
+        decision_label="Store AIP location", choice_value="Default location"
+    )
+    context.am_user.browser.save_default_processing_config()
+
+
 @when(
     'a "{reingest_type}" reingest is started using the "{processing_config}" processing configuration'
 )
@@ -101,12 +122,23 @@ def step_impl(context):
     context.current_transfer.update(
         utils.finish_reingest(
             context.api_clients_config,
+            context.current_transfer["transfer_name"],
+            context.current_transfer["transfer_uuid"],
             context.current_transfer["reingest_type"],
             context.current_transfer["reingest_uuid"],
         )
     )
     utils.is_valid_download(context.current_transfer["aip_mets_location"])
     utils.is_valid_download(context.current_transfer["reingest_aip_mets_location"])
+
+
+@when('the "{metadata_file}" metadata file is added')
+def step_impl(context, metadata_file):
+    utils.copy_metadata_files(
+        context.api_clients_config,
+        context.current_transfer["sip_uuid"],
+        [metadata_file],
+    )
 
 
 @then("the AIP METS can be accessed and parsed by mets-reader-writer")
@@ -514,6 +546,24 @@ def step_impl(context, microservice_name):
     )
 
 
+@then('the "{microservice_name}" microservice completes successfully')
+def step_impl(context, microservice_name):
+    utils.assert_jobs_completed_successfully(
+        context.api_clients_config,
+        context.current_transfer["transfer_uuid"],
+        job_microservice=microservice_name,
+    )
+
+
+@then('the "{microservice_name}" ingest microservice completes successfully')
+def step_impl(context, microservice_name):
+    utils.assert_jobs_completed_successfully(
+        context.api_clients_config,
+        context.current_transfer["sip_uuid"],
+        job_microservice=microservice_name,
+    )
+
+
 @then("the METS file contains a dmdSec with DDI metadata")
 def step_impl(context):
     tree = etree.parse(context.current_transfer["aip_mets_location"])
@@ -653,3 +703,128 @@ def step_impl(context, expected_entries_count):
         expected_entries_count, len(submission_docs)
     )
     assert len(submission_docs) == expected_entries_count, error
+
+
+@then('the "{metadata_file}" file is in the reingest metadata directory')
+def step_impl(context, metadata_file):
+    utils.is_valid_download(
+        utils.get_aip_file_location(
+            context.current_transfer["reingest_extracted_aip_dir"],
+            os.path.join("data", "objects", "metadata", metadata_file),
+        )
+    )
+
+
+@then("the DIP is downloaded")
+def step_impl(context):
+    context.current_transfer.update(
+        utils.get_dip(context.api_clients_config, context.current_transfer["sip_uuid"])
+    )
+
+
+@then("the DIP contains access copies for each original object in the transfer")
+def step_impl(context):
+    mets = metsrw.METSDocument.fromfile(context.current_transfer["aip_mets_location"])
+    # get the UUID of each 'original' file
+    original_file_uuids = set(
+        [fsentry.file_uuid for fsentry in mets.all_files() if fsentry.use == "original"]
+    )
+    assert original_file_uuids, format_original_files_error(context.current_transfer)
+    # verify each file UUID has a matching entry in the objects directory of the DIP
+    dip_file_uuids = set(
+        [
+            f[:36]
+            for f in os.listdir(
+                os.path.join(context.current_transfer["extracted_dip_dir"], "objects")
+            )
+        ]
+    )
+    error = "The DIP at {} does not contain access copies for all the original files of the {} AIP".format(
+        context.current_transfer["extracted_dip_dir"],
+        context.current_transfer["sip_uuid"],
+    )
+    assert original_file_uuids == dip_file_uuids, error
+
+
+@then(
+    "every file in the reingested metadata.csv file has two dmdSecs with the original and updated metadata"
+)
+def step_impl(context):
+    expected_dmdsec_status = ("original", "updated")
+    assert context.current_transfer[
+        "metadata_csv_files"
+    ], "Could not extract the rows of the original metadata.csv in {}".format(
+        context.current_transfer["extracted_aip_dir"]
+    )
+    assert context.current_transfer[
+        "reingest_metadata_csv_files"
+    ], "Could not extract the rows of the reingested metadata.csv in {}".format(
+        context.current_transfer["reingest_extracted_aip_dir"]
+    )
+    reingest_mets = metsrw.METSDocument.fromfile(
+        context.current_transfer["reingest_aip_mets_location"]
+    )
+    # XXX: using lxml to bypass an issue with metsrw where a dmdSec with status
+    #      `updated` resets the status of the previous dmdSec to `None`
+    reingest_tree = etree.parse(context.current_transfer["reingest_aip_mets_location"])
+    original_metadata_csv_filenames = [
+        row["filename"] for row in context.current_transfer["metadata_csv_files"]
+    ]
+    rows = [
+        row
+        for row in context.current_transfer["reingest_metadata_csv_files"]
+        if row["filename"] in original_metadata_csv_filenames
+    ]
+    assert rows, "Could not find any existing files in the reingested metadata.csv file"
+    namespaces_by_url = {v: k for k, v in context.mets_nsmap.items()}
+    errors = []
+    dmdsec_error_template = (
+        'Expected one dmdSec for filename "{}" with STATUS="{}" in metadata.csv '
+        "but got {}"
+    )
+    content_error_template = (
+        "Expected the dmdSec with status {} to contain an element {} "
+        "that matches the contents of the reingested metadadata.csv file"
+    )
+    for row in rows:
+        entry = reingest_mets.get_file(path=row["filename"])
+        all_dmdsecs = {}
+        dmdsecs_errors = []
+        for expected_status in expected_dmdsec_status:
+            dmdsecs = []
+            for dmdsec in entry.dmdsecs:
+                # XXX: using lxml to bypass an issue with metsrw mentioned above
+                if (
+                    len(
+                        reingest_tree.xpath(
+                            '//mets:dmdSec[@ID="{}"][@STATUS="{}"]'.format(
+                                dmdsec.id_string, expected_status
+                            ),
+                            namespaces=context.mets_nsmap,
+                        )
+                    )
+                    == 1
+                ):
+                    dmdsecs.append(dmdsec)
+            if len(dmdsecs) != 1:
+                dmdsecs_errors.append(
+                    dmdsec_error_template.format(
+                        row["filename"], ", ".join(expected_status), len(dmdsecs)
+                    )
+                )
+                continue
+            all_dmdsecs[expected_status] = dmdsecs[0]
+        if dmdsecs_errors:
+            errors.extend(dmdsecs_errors)
+            continue
+        # compare the newest dmdSec with the contents of the reingested csv
+        for child in all_dmdsecs.get(expected_dmdsec_status[-1]).contents.document:
+            q_name = etree.QName(child.tag)
+            ns = q_name.namespace
+            localname = q_name.localname
+            csv_field = "{}.{}".format(namespaces_by_url[ns], localname)
+            if row.get(csv_field) != child.text.strip():
+                errors.append(
+                    content_error_template.format(expected_dmdsec_status[-1], csv_field)
+                )
+    assert not errors, "\n".join(errors)

--- a/features/steps/black_box_steps.py
+++ b/features/steps/black_box_steps.py
@@ -414,7 +414,9 @@ def step_impl(context):
 def step_impl(context, job_name):
     default_valid_exit_codes = (0,)
     valid_exit_codes_by_job_name = {
-        "Determine if transfer still contains packages": (0, 1)
+        "Assign UUIDs to directories": (0, 1),
+        "Determine if transfer contains packages": (0, 1),
+        "Determine if transfer still contains packages": (0, 1),
     }
     valid_exit_codes = valid_exit_codes_by_job_name.get(
         job_name, default_valid_exit_codes
@@ -422,6 +424,39 @@ def step_impl(context, job_name):
     utils.assert_jobs_completed_successfully(
         context.api_clients_config,
         context.current_transfer["transfer_uuid"],
+        job_name=job_name,
+        valid_exit_codes=valid_exit_codes,
+    )
+
+
+@then('the "{job_name}" ingest job completes successfully')
+def step_impl(context, job_name):
+    default_valid_exit_codes = (0,)
+    valid_exit_codes_by_job_name = {
+        "Bind PID": (0, 1),
+        "Check for Access directory": (0, 179),
+        "Check for manual normalized files": (0, 179),
+        "Check if AIP is a file or directory": (0, 1),
+        "Check if DIP should be generated": (0, 1),
+        "Check if SIP is from Maildir Transfer": (0, 179),
+        "Index AIP": (0, 179),
+        "Is maildir AIP": (0, 179),
+        "Normalize for access": (0, 1, 2),
+        "Normalize for preservation": (0, 1, 2),
+        "Normalize for thumbnails": (0, 1, 2),
+        "Normalize service files for access": (0, 1, 2),
+        "Normalize service files for thumbnails": (0, 1, 2),
+        "Policy checks for access derivatives": (0, 1),
+        "Policy checks for preservation derivatives": (0, 1),
+        "Validate access derivatives": (0, 1),
+        "Validate preservation derivatives": (0, 1),
+    }
+    valid_exit_codes = valid_exit_codes_by_job_name.get(
+        job_name, default_valid_exit_codes
+    )
+    utils.assert_jobs_completed_successfully(
+        context.api_clients_config,
+        context.current_transfer["sip_uuid"],
         job_name=job_name,
         valid_exit_codes=valid_exit_codes,
     )
@@ -436,11 +471,29 @@ def step_impl(context, job_name):
     )
 
 
+@then('the "{job_name}" ingest job fails')
+def step_impl(context, job_name):
+    utils.assert_jobs_fail(
+        context.api_clients_config,
+        context.current_transfer["sip_uuid"],
+        job_name=job_name,
+    )
+
+
 @then('the "{microservice_name}" microservice is executed')
 def step_impl(context, microservice_name):
     utils.assert_microservice_executes(
         context.api_clients_config,
         context.current_transfer["transfer_uuid"],
+        microservice_name,
+    )
+
+
+@then('the "{microservice_name}" ingest microservice is executed')
+def step_impl(context, microservice_name):
+    utils.assert_microservice_executes(
+        context.api_clients_config,
+        context.current_transfer["sip_uuid"],
         microservice_name,
     )
 

--- a/features/steps/black_box_steps.py
+++ b/features/steps/black_box_steps.py
@@ -70,6 +70,39 @@ def step_impl(context):
     context.am_user.browser.save_default_processing_config()
 
 
+@given("a processing configuration for partial reingests")
+def step_impl(context):
+    context.am_user.browser.reset_default_processing_config()
+    context.am_user.browser.set_processing_config_decision(
+        decision_label="Normalize", choice_value="Normalize for access"
+    )
+    context.am_user.browser.set_processing_config_decision(
+        decision_label="Approve normalization", choice_value="Yes"
+    )
+    context.am_user.browser.set_processing_config_decision(
+        decision_label="Reminder: add metadata if desired", choice_value="Continue"
+    )
+    context.am_user.browser.set_processing_config_decision(
+        decision_label="Transcribe files (OCR)", choice_value="No"
+    )
+    context.am_user.browser.set_processing_config_decision(
+        decision_label="Store AIP", choice_value="Yes"
+    )
+    context.am_user.browser.set_processing_config_decision(
+        decision_label="Store AIP location", choice_value="Default location"
+    )
+    context.am_user.browser.set_processing_config_decision(
+        decision_label="Upload DIP", choice_value="Do not upload DIP"
+    )
+    context.am_user.browser.set_processing_config_decision(
+        decision_label="Store DIP", choice_value="Store DIP"
+    )
+    context.am_user.browser.set_processing_config_decision(
+        decision_label="Store DIP location", choice_value="Default location"
+    )
+    context.am_user.browser.save_default_processing_config()
+
+
 @when(
     'a "{reingest_type}" reingest is started using the "{processing_config}" processing configuration'
 )

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -449,6 +449,19 @@ def approve_transfer(api_clients_config, transfer_uuid):
         raise environment.EnvironmentError(response["error"])
 
 
+def approve_partial_reingest(api_clients_config, reingest_uuid):
+    response = check_unit_status(api_clients_config, reingest_uuid, "ingest")
+    if response.get("status") == "USER_INPUT":
+        am = configure_am_client(api_clients_config[AM_API_CONFIG_KEY])
+        am.sip_uuid = response["uuid"]
+        response = call_api_endpoint(
+            endpoint=am.approve_partial_reingest, warning_message="", error_message=""
+        )
+        if not response.get("error"):
+            return response["uuid"]
+        raise environment.EnvironmentError(response["error"])
+
+
 def start_reingest(
     api_clients_config,
     transfer_name,
@@ -476,8 +489,8 @@ def start_reingest(
         error_message="Cannot reingest AIP",
     )
     reingest_uuid = response.get("reingest_uuid")
-    time.sleep(environment.MEDIUM_WAIT)
-    return approve_transfer(api_clients_config, reingest_uuid)
+    assert reingest_uuid, "Cannot reingest AIP"
+    return reingest_uuid
 
 
 def check_unit_status(api_clients_config, unit_uuid, unit="transfer"):
@@ -737,7 +750,10 @@ def get_transfer_result(api_clients_config, transfer_uuid):
     transfer_response = wait_for_transfer(api_clients_config, transfer_uuid)
     if transfer_response["status"] == "FAILED":
         return {}
-    sip_uuid = transfer_response["sip_uuid"]
+    return get_ingest_result(api_clients_config, transfer_response["sip_uuid"])
+
+
+def get_ingest_result(api_clients_config, sip_uuid):
     ingest_response = wait_for_ingest(api_clients_config, sip_uuid)
     if ingest_response["status"] == "FAILED":
         return {}
@@ -765,23 +781,35 @@ def create_sample_transfer(
     return transfer
 
 
-def create_reingest(api_clients_config, transfer):
-    result = {}
+def create_reingest(api_clients_config, transfer, reingest_type, processing_config):
     try:
-        result["reingest_transfer_uuid"] = start_reingest(
-            api_clients_config, transfer["transfer_name"], transfer["sip_uuid"]
+        reingest_uuid = start_reingest(
+            api_clients_config,
+            transfer["transfer_name"],
+            transfer["sip_uuid"],
+            reingest_type,
+            processing_config,
         )
     except environment.EnvironmentError as err:
         assert False, "Error starting reingest: {}".format(err)
-    reingest_transfer_result = get_transfer_result(
-        api_clients_config, result["reingest_transfer_uuid"]
-    )
-    if not reingest_transfer_result:
-        return reingest_transfer_result
-    result["reingest_sip_uuid"] = reingest_transfer_result["sip_uuid"]
-    result["reingest_extracted_aip_dir"] = reingest_transfer_result["extracted_aip_dir"]
-    result["reingest_aip_mets_location"] = reingest_transfer_result["aip_mets_location"]
-    return result
+    else:
+        return {
+            "reingest_uuid": reingest_uuid,
+            "reingest_type": reingest_type,
+            "reingest_processing_config": processing_config,
+        }
+
+
+def finish_reingest(api_clients_config, reingest_type, reingest_uuid):
+    if reingest_type == "FULL":
+        result = get_transfer_result(api_clients_config, reingest_uuid)
+        return {
+            "reingest_uuid": result["sip_uuid"],
+            "reingest_extracted_aip_dir": result["extracted_aip_dir"],
+            "reingest_aip_mets_location": result["aip_mets_location"],
+        }
+    else:
+        raise NotImplementedError("Not yet")
 
 
 def get_jobs(

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -753,9 +753,6 @@ def get_transfer_result(api_clients_config, transfer_uuid):
 def create_sample_transfer(
     api_clients_config, sample_transfer_path, transfer_type="standard"
 ):
-    cached_transfer = environment.transfers_cache.setdefault(sample_transfer_path, {})
-    if "aip_mets_location" in cached_transfer:
-        return cached_transfer
     transfer = start_sample_transfer(
         api_clients_config, sample_transfer_path, transfer_type=transfer_type
     )
@@ -765,13 +762,10 @@ def create_sample_transfer(
     transfer["sip_uuid"] = transfer_result["sip_uuid"]
     transfer["extracted_aip_dir"] = transfer_result["extracted_aip_dir"]
     transfer["aip_mets_location"] = transfer_result["aip_mets_location"]
-    cached_transfer.update(transfer)
     return transfer
 
 
 def create_reingest(api_clients_config, transfer):
-    if "reingest_aip_mets_location" in transfer:
-        return transfer
     result = {}
     try:
         result["reingest_transfer_uuid"] = start_reingest(

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,8 +1,8 @@
-amclient==1.1.1
+amclient
 behave>=1.0
 lxml
 metsrw
 pexpect
 requests<3.0
-tenacity==7.0.0
-selenium==3.141.0
+tenacity
+selenium<4.0


### PR DESCRIPTION
This adds scenarios for testing partial (e.g. objects) and metadata only reingests.

It also splits the existing full reingest scenarios to make the approval step explicit.

Due to the lack of API endpoints for creating and modifying processing configurations this reuses the dashboard UI steps to make the partial reingest workflows fully automated.

Connected to https://github.com/archivematica/Issues/issues/959