### PR TITLE
Update Chrome and ChromeDriver set up

### DIFF
--- a/simplebrowsertest.py
+++ b/simplebrowsertest.py
@@ -12,6 +12,8 @@ def get_chrome_driver():
     options = webdriver.ChromeOptions()
     options.add_argument("headless")
     options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--whitelisted-ips")
     driver = webdriver.Chrome(chrome_options=options)
     driver.set_window_size(1700, 900)
     return driver


### PR DESCRIPTION
This sets up Chrome and ChromeDriver using the new [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/) approach which is more convenient for automated testing since it relies on [API endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints) instead of OS packages with manual version matching.

A few new libraries have been added to the `Dockerfile` and the simple browser test has been updated to make it work with the newer versions of all the related components.

For more reference see:
* https://groups.google.com/g/chromedriver-users/c/clpipqvOGjE
* [ChromeDriver version selection](https://chromedriver.chromium.org/downloads/version-selection)

Connected to https://github.com/archivematica/Issues/issues/1613