### PR TITLE
Fix selenium-manager download URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN set -ex \
 	&& SELENIUM_CACHE=${SELENIUM_DIR}/cache \
 	&& SELENIUM_BIN=${SELENIUM_DIR}/bin \
 	&& mkdir -p $SELENIUM_CACHE $SELENIUM_BIN \
-	&& curl -o $SELENIUM_BIN/selenium-manager -L https://github.com/SeleniumHQ/selenium/raw/trunk/common/manager/linux/selenium-manager \
+	&& curl -o $SELENIUM_BIN/selenium-manager -L https://github.com/SeleniumHQ/selenium/raw/selenium-4.16.0/common/manager/linux/selenium-manager \
 	&& chmod +x $SELENIUM_BIN/selenium-manager \
 	&& CHROME_OUTPUT=$($SELENIUM_BIN/selenium-manager --cache-path $SELENIUM_CACHE --browser chrome --output JSON) \
 	&& FIREFOX_OUTPUT=$($SELENIUM_BIN/selenium-manager --cache-path $SELENIUM_CACHE --browser firefox --output JSON) \


### PR DESCRIPTION
The Selenium project recently moved their `selenium-manager` release binaries to a [separate repository](https://github.com/SeleniumHQ/selenium_manager_artifacts/).

For now this updates the download URL to use the most recent git tag that contains the binaries. Once they update their [Getting Selenium Manager](https://www.selenium.dev/documentation/selenium_manager/#getting-selenium-manager) section with the new approach we'll switch to it.