### PR TITLE
Use old headless mode in Chrome browser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,10 @@ FROM base AS archivematica-acceptance-tests
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 
+ENV SE_MANAGER_PATH=${SELENIUM_DIR}/bin/selenium-manager
+ENV SE_CHROME_PATH=${SELENIUM_DIR}/bin/google-chrome
+ENV SE_FIREFOX_PATH=${SELENIUM_DIR}/bin/firefox
+
 RUN set -ex \
 	&& apt-get -qqy update \
 	&& apt-get -qqy --no-install-recommends install \

--- a/amuser/selenium_ability.py
+++ b/amuser/selenium_ability.py
@@ -39,7 +39,7 @@ class ArchivematicaSeleniumAbility(base.Base):
         if self.driver_name == "Chrome":
             options = webdriver.ChromeOptions()
             if headless:
-                options.add_argument("--headless=new")
+                options.add_argument("--headless=old")
             driver = webdriver.Chrome(options=options)
             driver.set_window_size(1700, 900)
         elif self.driver_name == "Firefox":

--- a/simplebrowsertest.py
+++ b/simplebrowsertest.py
@@ -8,7 +8,7 @@ TEST_TITLE = "Home | Artefactual"
 
 def get_chrome_driver():
     options = webdriver.ChromeOptions()
-    options.add_argument("--headless")
+    options.add_argument("--headless=old")
     driver = webdriver.Chrome(options=options)
     return driver
 


### PR DESCRIPTION
Google Chrome and Chromedriver v129 broke [headless mode](https://www.selenium.dev/blog/2023/headless-is-going-away/) in Selenium's webdriver.

This sets the `old` mode in Chrome until a fix in either project is released. It also sets [environment variables](https://www.selenium.dev/documentation/selenium_manager/#configuration) in the Docker stage to prevent Selenium from downloading the browsers on its first run, and instead to reuse the ones set during the Docker build.