### PR TITLE
Use new headless mode in Google Chrome

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,13 @@ repos:
   hooks:
   - id: end-of-file-fixer
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.1
+  rev: v0.9.5
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
   - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.14.1
+  rev: v1.15.0
   hooks:
   - id: mypy
     additional_dependencies:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
 		ca-certificates \
 		curl \
 		git \
+		gnupg \
 		jq \
 		locales \
 	&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
@@ -43,10 +44,7 @@ RUN set -ex \
 	&& SELENIUM_MANAGER_DOWNLOAD_URL=$(curl -sL -o /dev/null -w '%{url_effective}' https://github.com/SeleniumHQ/selenium_manager_artifacts/releases/latest | sed -e 's|/tag/\(.*\)|/download/\1/selenium-manager-linux|g') \
 	&& curl -o $SELENIUM_BIN/selenium-manager -L $SELENIUM_MANAGER_DOWNLOAD_URL \
 	&& chmod +x $SELENIUM_BIN/selenium-manager \
-	&& CHROME_OUTPUT=$($SELENIUM_BIN/selenium-manager --cache-path $SELENIUM_CACHE --browser chrome --output JSON) \
 	&& FIREFOX_OUTPUT=$($SELENIUM_BIN/selenium-manager --cache-path $SELENIUM_CACHE --browser firefox --output JSON) \
-	&& ln -s $(echo $CHROME_OUTPUT | jq -r '.result.browser_path') $SELENIUM_BIN/google-chrome \
-	&& ln -s $(echo $CHROME_OUTPUT | jq -r '.result.driver_path') $SELENIUM_BIN/chromedriver \
 	&& ln -s $(echo $FIREFOX_OUTPUT | jq -r '.result.browser_path') $SELENIUM_BIN/firefox \
 	&& ln -s $(echo $FIREFOX_OUTPUT | jq -r '.result.driver_path') $SELENIUM_BIN/geckodriver
 
@@ -94,14 +92,17 @@ ARG USER_ID=1000
 ARG GROUP_ID=1000
 
 ENV SE_MANAGER_PATH=${SELENIUM_DIR}/bin/selenium-manager
-ENV SE_CHROME_PATH=${SELENIUM_DIR}/bin/google-chrome
+ENV SE_CHROME_PATH=/usr/bin/google-chrome
 ENV SE_FIREFOX_PATH=${SELENIUM_DIR}/bin/firefox
 
 RUN set -ex \
+	&& curl -fSsL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
+	&& echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
 	&& apt-get -qqy update \
 	&& apt-get -qqy --no-install-recommends install \
 		bzip2 \
 		gnupg \
+		google-chrome-stable \
 		libasound2 \
 		libdbus-glib-1-2 \
 		libdrm2 \
@@ -123,6 +124,13 @@ RUN set -ex \
 COPY --chown=${USER_ID}:${GROUP_ID} --from=browsers-builder --link /selenium /selenium
 COPY --chown=${USER_ID}:${GROUP_ID} --from=pyenv-builder --link /pyenv /pyenv
 COPY --chown=${USER_ID}:${GROUP_ID} --link . /home/artefactual/acceptance-tests
+
+# Download the ChromeDriver version that matches the recently installed version
+# of Google Chrome.
+RUN set -ex \
+	&& GOOGLE_CHROME_VERSION=$(google-chrome --version | cut --delimiter ' ' --fields 3) \
+	&& CHROME_OUTPUT=$($SELENIUM_DIR/bin/selenium-manager --cache-path $SELENIUM_DIR/cache --browser chrome --driver-version $GOOGLE_CHROME_VERSION --output JSON --avoid-browser-download) \
+	&& ln -s $(echo $CHROME_OUTPUT | jq -r '.result.driver_path') $SELENIUM_DIR/bin/chromedriver
 
 RUN set -ex \
 	&& groupadd --gid ${GROUP_ID} artefactual \

--- a/amuser/selenium_ability.py
+++ b/amuser/selenium_ability.py
@@ -39,7 +39,7 @@ class ArchivematicaSeleniumAbility(base.Base):
         if self.driver_name == "Chrome":
             options = webdriver.ChromeOptions()
             if headless:
-                options.add_argument("--headless=old")
+                options.add_argument("--headless=new")
             driver = webdriver.Chrome(options=options)
             driver.set_window_size(1700, 900)
         elif self.driver_name == "Firefox":

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 amclient==1.4.0
     # via -r requirements.txt
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   -r requirements.txt
     #   outcome
@@ -15,9 +15,9 @@ behave==1.2.6
     # via -r requirements.txt
 build==1.2.2.post1
     # via pip-tools
-cachetools==5.5.0
+cachetools==5.5.1
     # via tox
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -r requirements.txt
     #   requests
@@ -39,7 +39,7 @@ exceptiongroup==1.2.2
     #   -r requirements.txt
     #   trio
     #   trio-websocket
-filelock==3.16.1
+filelock==3.17.0
     # via
     #   tox
     #   virtualenv
@@ -52,7 +52,7 @@ idna==3.10
     #   -r requirements.txt
     #   requests
     #   trio
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via build
 lxml==5.3.0
     # via
@@ -92,7 +92,7 @@ ptyprocess==0.7.0
     # via
     #   -r requirements.txt
     #   pexpect
-pyproject-api==1.8.0
+pyproject-api==1.9.0
     # via tox
 pyproject-hooks==1.2.0
     # via
@@ -106,9 +106,9 @@ requests==2.32.3
     # via
     #   -r requirements.txt
     #   amclient
-ruff==0.9.1
+ruff==0.9.5
     # via -r requirements-dev.in
-selenium==4.27.1
+selenium==4.28.1
     # via -r requirements.txt
 six==1.17.0
     # via
@@ -131,7 +131,7 @@ tomli==2.2.1
     #   pip-tools
     #   pyproject-api
     #   tox
-tox==4.23.2
+tox==4.24.1
     # via -r requirements-dev.in
 trio==0.28.0
     # via
@@ -153,7 +153,7 @@ urllib3[socks]==2.3.0
     #   amclient
     #   requests
     #   selenium
-virtualenv==20.28.1
+virtualenv==20.29.1
     # via tox
 websocket-client==1.8.0
     # via
@@ -169,7 +169,7 @@ zipp==3.21.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.3.1
+pip==25.0
     # via pip-tools
 setuptools==75.8.0
     # via pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,13 +6,13 @@
 #
 amclient==1.4.0
     # via -r requirements.in
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   outcome
     #   trio
 behave==1.2.6
     # via -r requirements.in
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   requests
     #   selenium
@@ -52,7 +52,7 @@ requests==2.32.3
     # via
     #   -r requirements.in
     #   amclient
-selenium==4.27.1
+selenium==4.28.1
     # via -r requirements.in
 six==1.17.0
     # via

--- a/simplebrowsertest.py
+++ b/simplebrowsertest.py
@@ -8,7 +8,7 @@ TEST_TITLE = "Home | Artefactual"
 
 def get_chrome_driver():
     options = webdriver.ChromeOptions()
-    options.add_argument("--headless=old")
+    options.add_argument("--headless=new")
     driver = webdriver.Chrome(options=options)
     return driver
 


### PR DESCRIPTION
This uses the [new headless mode](https://developer.chrome.com/docs/chromium/headless) in Google Chrome. The old mode stopped working in our setup with Chrome 132.

Unfortunately, [the Chrome for Testing alternative](https://developer.chrome.com/blog/chrome-for-testing/) which is more efficient than the standard version seems problematic to handle sessions switches between the Storage Service and the Dashboard resulting in flaky behavior, so this replaces it with the standard Google Chrome browser.

Connected to https://github.com/archivematica/Issues/issues/1720