### PR TITLE
Use GPG key ids in encryption tests

### DIFF
--- a/amuser/am_browser_ss_ability.py
+++ b/amuser/am_browser_ss_ability.py
@@ -15,6 +15,13 @@ from . import utils
 logger = logging.getLogger("amuser.ss")
 
 
+# These correspond to the keys used in the key import test.
+GPG_KEYIDS_TO_IMPORT = {
+    "AAC5E07B370A2D9A": "aadams-passphraseless.key",
+    "0F86C799E5DEDE22": "bbingo-passphrased.key",
+}
+
+
 class ArchivematicaBrowserStorageServiceAbilityError(base.ArchivematicaUserError):
     pass
 
@@ -125,6 +132,21 @@ class ArchivematicaBrowserStorageServiceAbility(
         if attributes.get("Access protocol") == "GPG encryption on Local Filesystem":
             # Visiting this URL creates a default GPG key when there is none
             self.navigate(self.get_gpg_keys_url())
+            if (
+                attributes.get("GnuPG Private Key")
+                == "Archivematica Storage Service GPG Key"
+            ):
+                # Replace the name of the default GPG encryption key with its
+                # key ID, ignoring any keys imported in other tests.
+                key_ids = [
+                    a.text
+                    for a in self.driver.find_elements(
+                        By.CSS_SELECTOR, "tbody tr td:first-child a"
+                    )
+                    if a.text not in GPG_KEYIDS_TO_IMPORT
+                ]
+                assert key_ids
+                attributes["GnuPG Private Key"] = key_ids[0]
         self.navigate(self.get_spaces_create_url())
         form_el = self.driver.find_element(
             By.CSS_SELECTOR, 'form[action="/spaces/create/"]'
@@ -439,7 +461,8 @@ class ArchivematicaBrowserStorageServiceAbility(
         self.wait_for_presence("div.alert-success", self.nihilistic_wait)
         alert_text = self.driver.find_element(By.CSS_SELECTOR, "div.alert-success").text
         new_key_fingerprint = alert_text.split()[2]
-        return new_key_name, new_key_email, new_key_fingerprint
+        new_key_id = self.driver.find_elements(By.CSS_SELECTOR, "dd")[1].text
+        return new_key_name, new_key_email, new_key_fingerprint, new_key_id
 
     def change_encrypted_space_key(self, space_uuid, new_key_repr=None):
         """Edit the existing space with UUID ``space_uuid`` and set its GPG key

--- a/features/core/aip-encryption.feature
+++ b/features/core/aip-encryption.feature
@@ -73,12 +73,12 @@ Feature: AIP Encryption
   @allow-passphraseless-key-import
   Scenario: Richard wants to ensure that a passphrase-less GPG key can be imported into the storage service.
     When the user attempts to import GPG key aadams-passphraseless.key
-    Then the user succeeds in importing the GPG key aadams
+    Then the user succeeds in importing the GPG key AAC5E07B370A2D9A
 
   @prohibit-passphrased-key-import
   Scenario: Richard wants to ensure that a GPG key with a passphrase cannot be imported into the storage service. Keys with passphrases would break the storage service's encryption functionality.
     When the user attempts to import GPG key bbingo-passphrased.key
-    Then the user fails to import the GPG key bbingo because it requires a passphrase
+    Then the user fails to import the GPG key 0F86C799E5DEDE22 because it requires a passphrase
 
   @allow-orphaned-key-delete
   Scenario: Richard wants to ensure that GPG deletion is never permitted if the key is associated to a space or if it is needed to decrypt an existing package. However, if all space associations are destroyed and all dependent packages deleted, then deletion of the (orphaned) key should be permitted.

--- a/features/steps/aip_encryption_steps.py
+++ b/features/steps/aip_encryption_steps.py
@@ -147,9 +147,10 @@ def step_impl(context):
         new_key_name,
         new_key_email,
         new_key_fingerprint,
+        new_key_id,
     ) = context.am_user.browser.create_new_gpg_key()
-    context.scenario.new_key_name = new_key_name
     context.scenario.new_key_fingerprint = new_key_fingerprint
+    context.scenario.new_key_id = new_key_id
     if getattr(context.scenario, "space_uuid", None) is not None:
         # Don't look for a space if previos steps saved it
         standard_encr_space_uuid = context.scenario.space_uuid
@@ -160,13 +161,13 @@ def step_impl(context):
                 "Access protocol": "GPG encryption on Local Filesystem",
                 "Path": "/",
                 "Staging path": "/var/archivematica/storage_service/storage_service_encrypted",
-                "GnuPG Private Key": "Archivematica Storage Service GPG Key",
+                "GnuPG Private Key": new_key_id,
             }
         )["uuid"]
     new_key_repr = f"{new_key_name} <{new_key_email}>"
     logger.info('Created a new GPG key "%s"', new_key_repr)
     context.am_user.browser.change_encrypted_space_key(
-        standard_encr_space_uuid, new_key_repr
+        standard_encr_space_uuid, new_key_id
     )
 
 
@@ -189,18 +190,18 @@ def step_impl(context, transfer_path):
 
 @when("the user attempts to delete the new GPG key")
 def step_impl(context):
-    new_key_name = context.scenario.new_key_name
-    logger.info('Attempting to delete GPG key "%s"', new_key_name)
+    new_key_id = context.scenario.new_key_id
+    logger.info('Attempting to delete GPG key "%s"', new_key_id)
     (
         context.scenario.delete_gpg_key_success,
         context.scenario.delete_gpg_key_msg,
-    ) = context.am_user.browser.delete_gpg_key(new_key_name)
+    ) = context.am_user.browser.delete_gpg_key(new_key_id)
     if context.scenario.delete_gpg_key_success:
-        logger.info('Attempt to delete GPG key "%s" was SUCCESSFUL', new_key_name)
+        logger.info('Attempt to delete GPG key "%s" was SUCCESSFUL', new_key_id)
     else:
         logger.info(
             'Attempt to delete GPG key "%s" FAILED: "%s"',
-            new_key_name,
+            new_key_id,
             context.scenario.delete_gpg_key_msg,
         )
 
@@ -208,7 +209,7 @@ def step_impl(context):
 @when("the user assigns a different GPG key to the standard GPG-encrypted space")
 def step_impl(context):
     """Edit the standard GPG-encrypted space so that it is using a GPG key
-    other than the one stored in ``context.scenario.new_key_name``.
+    other than the one stored in ``context.scenario.new_key_id``.
     """
     if getattr(context.scenario, "space_uuid", None) is not None:
         # Don't look for a space if previos steps saved it
@@ -220,7 +221,7 @@ def step_impl(context):
                 "Access protocol": "GPG encryption on Local Filesystem",
                 "Path": "/",
                 "Staging path": "/var/archivematica/storage_service/storage_service_encrypted",
-                "GnuPG Private Key": context.scenario.new_key_name,
+                "GnuPG Private Key": context.scenario.new_key_id,
             }
         )["uuid"]
     context.am_user.browser.change_encrypted_space_key(standard_encr_space_uuid)


### PR DESCRIPTION
After https://github.com/artefactual/archivematica-storage-service/pull/785 the user interface of the Storage Service uses GPG encryption key ids as identifiers. This updates the encryption tests accordingly.

Connected to https://github.com/archivematica/Issues/issues/1737