### PR TITLE
Add compatibility with the new processing monitor

### DIFF
--- a/amuser/am_browser_jobs_tasks_ability.py
+++ b/amuser/am_browser_jobs_tasks_ability.py
@@ -53,17 +53,28 @@ class ArchivematicaBrowserJobsTasksAbility(
         self.navigate(unit_url)
         ms_name, group_name = utils.micro_service2group(ms_name)
         logger.info("expecting job %s to be in group %s", ms_name, group_name)
-        # If not visible, click the micro-service group to expand it.
+        # In the Vue monitor, the job container may not exist in the DOM until
+        # the group is expanded (v-if). For compatibility, also support legacy
+        # markup where the container is the sibling after `.microservice-group`.
         self.wait_for_transfer_micro_service_group(group_name, transfer_uuid)
-        is_visible = (
-            self.get_transfer_micro_service_group_elem(group_name, transfer_uuid)
-            .find_element(By.CSS_SELECTOR, "div.microservice-group + div")
-            .is_displayed()
+        ms_group_elem = self.get_transfer_micro_service_group_elem(
+            group_name, transfer_uuid
         )
+        job_container_els = ms_group_elem.find_elements(
+            By.CSS_SELECTOR, "div.job-container"
+        )
+        if not job_container_els:
+            job_container_els = ms_group_elem.find_elements(
+                By.CSS_SELECTOR, "div.microservice-group + div"
+            )
+        is_visible = any(el.is_displayed() for el in job_container_els)
         if not is_visible:
-            self.get_transfer_micro_service_group_elem(
-                group_name, transfer_uuid
-            ).click()
+            try:
+                ms_group_elem.find_element(
+                    By.CSS_SELECTOR, "div.microservice-group"
+                ).click()
+            except NoSuchElementException:
+                ms_group_elem.click()
         self.wait_for_microservice_visibility(ms_name, group_name, transfer_uuid)
         logger.info("exposed job %s (%s)", ms_name, group_name)
         return ms_name, group_name

--- a/amuser/am_browser_transfer_ability.py
+++ b/amuser/am_browser_transfer_ability.py
@@ -93,26 +93,51 @@ class ArchivematicaBrowserTransferAbility(
         """Remove the topmost transfer: click on its "Remove" button and click
         "Confirm".
         """
+        try:
+            row_elem = top_transfer_elem.find_element(By.CSS_SELECTOR, "div.sip-row")
+            row_elem.click()
+        except NoSuchElementException:
+            pass
         remove_elem = top_transfer_elem.find_element(
             By.CSS_SELECTOR, "a.btn_remove_sip"
         )
         if remove_elem:
             remove_elem.click()
-            dialog_selector = "div.ui-dialog"
-            self.wait_for_presence(dialog_selector)
-            remove_sip_confirm_dialog_elems = self.driver.find_elements(
-                By.CSS_SELECTOR, "div.ui-dialog"
-            )
-            for dialog_elem in remove_sip_confirm_dialog_elems:
+            old_dialog_selector = "div.ui-dialog"
+            new_dialog_selector = "div.monitor-modal.monitor-modal-visible"
+            if self.driver.find_elements(By.CSS_SELECTOR, old_dialog_selector):
+                self.wait_for_presence(old_dialog_selector)
+                dialog_elems = self.driver.find_elements(
+                    By.CSS_SELECTOR, old_dialog_selector
+                )
+            else:
+                self.wait_for_presence(new_dialog_selector)
+                dialog_elems = self.driver.find_elements(
+                    By.CSS_SELECTOR, new_dialog_selector
+                )
+            remove_sip_confirm_dialog_elem = None
+            for dialog_elem in dialog_elems:
                 if dialog_elem.is_displayed():
                     remove_sip_confirm_dialog_elem = dialog_elem
                     break
-            for button_elem in remove_sip_confirm_dialog_elem.find_elements(
-                By.CSS_SELECTOR, "button"
-            ):
-                if button_elem.text.strip() == "Confirm":
-                    button_elem.click()
-            self.wait_for_invisibility(dialog_selector)
+            if not remove_sip_confirm_dialog_elem:
+                raise NoSuchElementException(
+                    "Unable to locate visible remove confirmation dialog"
+                )
+            confirm_button_elems = remove_sip_confirm_dialog_elem.find_elements(
+                By.CSS_SELECTOR, "button.btn.btn-primary"
+            )
+            if confirm_button_elems:
+                confirm_button_elems[0].click()
+            else:
+                for button_elem in remove_sip_confirm_dialog_elem.find_elements(
+                    By.CSS_SELECTOR, "button"
+                ):
+                    if button_elem.text.strip() == "Confirm":
+                        button_elem.click()
+                        break
+            self.wait_for_invisibility(old_dialog_selector, timeout=self.apathetic_wait)
+            self.wait_for_invisibility(new_dialog_selector, timeout=self.apathetic_wait)
             try:
                 while top_transfer_elem.is_displayed():
                     time.sleep(self.quick_wait)

--- a/amuser/constants.py
+++ b/amuser/constants.py
@@ -259,9 +259,13 @@ JS_SNIPPET_GET_MICRO_SERVICES2GROUPS = """
         var group = $(this).find(
             'span.microservice-group-name').text().replace(
             'Micro-service: ', '');
-        var children = $(this).children();
-        if (!$(children[1]).is(':visible')) { children[0].click() }
-        $(children[1]).find('div.job').each(function(){
+        var header = $(this).find('div.microservice-group').first();
+        var container = $(this).find('div.job-container').first();
+        if (container.length === 0 || !container.is(':visible')) {
+            header.click();
+            container = $(this).find('div.job-container').first();
+        }
+        container.find('div.job').each(function(){
             var ms = $(this).find(
                 'div.job-detail-microservice span[title]').text();
             if (map_.hasOwnProperty(ms)) {


### PR DESCRIPTION
In the Vue rewrite, job containers are conditionally rendered (v-if), so the test now checks both new and legacy container patterns and expands the microservice group when the container is missing or hidden.