### PR TITLE
Accept newer uv releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG TARGET=archivematica-acceptance-tests
 
 ARG UBUNTU_VERSION=24.04
-# Keep these in sync with tool.uv.required-version in pyproject.toml.
+# Pin the Docker tool image independently for reproducible builds.
 ARG UV_VERSION=0.11.30
 ARG UV_DIGEST=sha256:93b61e21202b1dab861092748e46bbd6e0e41dd84f59b9174efd2353186e1b47
 ARG PYTHON_INSTALL_DIR=/python

--- a/README.rst
+++ b/README.rst
@@ -156,23 +156,22 @@ To upgrade the default Python version, update ``.python-version`` and run
 ``project.requires-python`` and the CI matrices; Ruff derives its target from
 the minimum supported version.
 
-The primary uv version declaration is ``tool.uv.required-version`` in
-``pyproject.toml``. Local uv commands enforce it, and the ``setup-uv`` GitHub
-Action reads it automatically. The Docker build must repeat the version because
-Docker cannot read project metadata in a ``FROM`` instruction; it also pins the
-image digest for reproducible builds. These are the only two version pins.
+``tool.uv.required-version`` in ``pyproject.toml`` declares the minimum uv
+version and intentionally accepts newer global installations. Local uv commands
+enforce it, and the ``setup-uv`` GitHub Action reads it automatically and
+selects a compatible release. The Docker build independently pins its uv image
+version and digest for reproducible builds.
 
-To upgrade uv, update ``tool.uv.required-version`` in ``pyproject.toml``
-together with ``UV_VERSION`` and ``UV_DIGEST`` in ``Dockerfile``. Obtain the
-multi-platform image digest with::
+To raise the minimum supported uv version, update
+``tool.uv.required-version``. To upgrade the Docker build's uv release, update
+``UV_VERSION`` and ``UV_DIGEST`` in ``Dockerfile``. Obtain the multi-platform
+image digest with::
 
     $ docker buildx imagetools inspect ghcr.io/astral-sh/uv:VERSION
 
 Standalone installer users can then run ``uv self update VERSION``; other
 installations must be updated through their package manager. Finally, run
-``make lock``, ``make check``, and ``make docker-build``. GitHub Actions will
-use the new version without another version change. If a local uv version is
-wrong, uv reports the exact update command before doing any project work.
+``make lock``, ``make check``, and ``make docker-build``.
 
 
 Install with deploy-pub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,9 @@ dev = [
 [tool.uv]
 # This repository is a test suite, not an installable Python package.
 package = false
+# Keep compatibility with newer global uv installations used by deployments.
 # GitHub Actions reads this value automatically via astral-sh/setup-uv.
-required-version = "==0.11.30"
+required-version = ">=0.11.30"
 
 [tool.ruff.lint]
 # Rule reference: https://docs.astral.sh/ruff/rules/


### PR DESCRIPTION
Treat uv 0.11.30 as the minimum supported version so role-managed hosts (Ansible) can use the latest global release. Keep the Docker tool image independently pinned for reproducible builds.