### PR TITLE
Speed up AMAUAT acceptance tests

### DIFF
--- a/amuser/am_api_ability.py
+++ b/amuser/am_api_ability.py
@@ -7,12 +7,15 @@ user's ability to use Archivematica's APIs to interact with Archivematica.
 import logging
 import os
 import time
+import xml.etree.ElementTree as ET
 
 import requests
 
 from . import base
 
 logger = logging.getLogger("amuser.api")
+
+CREATE_SIP_DECISION_ID = "bb194013-597c-4e4a-8493-b36d190f8717"
 
 
 class ArchivematicaAPIAbilityError(base.ArchivematicaUserError):
@@ -23,6 +26,121 @@ class ArchivematicaAPIAbility(base.Base):
     """Represents an Archivematica (AM) user's ability to use AM's APIs to
     interact with AM.
     """
+
+    def _authenticated_dashboard_session(self):
+        try:
+            return self._dashboard_session
+        except AttributeError:
+            pass
+
+        session = requests.Session()
+        login_url = self.get_login_url()
+        response = session.get(login_url, timeout=self.pessimistic_wait)
+        response.raise_for_status()
+        csrf_token = session.cookies.get("csrftoken")
+        if not csrf_token:
+            raise ArchivematicaAPIAbilityError(
+                "Unable to obtain a CSRF token from Archivematica"
+            )
+        response = session.post(
+            login_url,
+            data={
+                "csrfmiddlewaretoken": csrf_token,
+                "username": self.am_username,
+                "password": self.am_password,
+            },
+            headers={"Referer": login_url},
+            allow_redirects=False,
+            timeout=self.pessimistic_wait,
+        )
+        if response.status_code not in (301, 302) or not session.cookies.get(
+            "sessionid"
+        ):
+            raise ArchivematicaAPIAbilityError("Unable to log in to Archivematica")
+        self._dashboard_session = session
+        return session
+
+    def install_transfer_only_processing_config(self, name):
+        """Clone the automated config without its Create SIP(s) choice."""
+        session = self._authenticated_dashboard_session()
+        source_url = f"{self.am_url}api/processing-configuration/automated"
+        response = session.get(
+            source_url,
+            headers={"Accept": "application/xml"},
+            timeout=self.pessimistic_wait,
+        )
+        response.raise_for_status()
+        source_root = ET.fromstring(response.content)
+        choices = {
+            choice.findtext("appliesTo"): choice.findtext("goToChain")
+            for choice in source_root.findall(".//preconfiguredChoice")
+            if choice.findtext("appliesTo") != CREATE_SIP_DECISION_ID
+        }
+
+        add_url = f"{self.am_url}administration/processing/add/"
+        csrf_token = session.cookies.get("csrftoken")
+        response = session.post(
+            add_url,
+            data={
+                "csrfmiddlewaretoken": csrf_token,
+                "name": name,
+                **choices,
+            },
+            headers={"Referer": add_url},
+            allow_redirects=False,
+            timeout=self.pessimistic_wait,
+        )
+        if response.status_code not in (301, 302):
+            raise ArchivematicaAPIAbilityError(
+                f'Unable to install processing configuration "{name}"'
+            )
+
+        target_url = f"{self.am_url}api/processing-configuration/{name}"
+        response = session.get(
+            target_url,
+            headers={"Accept": "application/xml"},
+            timeout=self.pessimistic_wait,
+        )
+        response.raise_for_status()
+        target_root = ET.fromstring(response.content)
+        installed_choices = {
+            choice.findtext("appliesTo"): choice.findtext("goToChain")
+            for choice in target_root.findall(".//preconfiguredChoice")
+        }
+        if installed_choices != choices:
+            raise ArchivematicaAPIAbilityError(
+                f'Processing configuration "{name}" was not installed correctly'
+            )
+
+    def reject_transfer(self, transfer_uuid):
+        """Reject a transfer paused at a Dashboard decision point."""
+        session = self._authenticated_dashboard_session()
+        list_url = f"{self.am_url}mcp/list/"
+        response = session.get(list_url, timeout=self.pessimistic_wait)
+        response.raise_for_status()
+        root = ET.fromstring(response.content)
+        for job in root:
+            if job.findtext("./unit/unitXML/UUID") != transfer_uuid:
+                continue
+            for choice in job.findall("./choices/choice"):
+                if choice.findtext("description") != "Reject transfer":
+                    continue
+                execute_url = f"{self.am_url}mcp/execute/"
+                response = session.post(
+                    execute_url,
+                    data={
+                        "csrfmiddlewaretoken": session.cookies.get("csrftoken"),
+                        "uuid": job.findtext("UUID"),
+                        "choice": choice.findtext("chainAvailable"),
+                    },
+                    headers={"Referer": list_url},
+                    timeout=self.pessimistic_wait,
+                )
+                response.raise_for_status()
+                return
+        raise ArchivematicaAPIAbilityError(
+            f"Unable to find the reject decision for transfer {transfer_uuid}"
+        )
 
     def download_aip(self, transfer_name, sip_uuid, ss_api_key):
         """Use the AM SS API to download the completed AIP.

--- a/amuser/am_api_ability.py
+++ b/amuser/am_api_ability.py
@@ -181,10 +181,14 @@ class ArchivematicaAPIAbility(base.Base):
                 )
                 raise ArchivematicaAPIAbilityError(f"Unable to download AIP {sip_uuid}")
 
-    def download_aip_pointer_file(self, sip_uuid, ss_api_key):
+    def download_aip_pointer_file(self, sip_uuid, ss_api_key, expected_content=None):
         """Use the AM SS API to download the completed AIP's pointer file.
         Calls http://localhost:8000/api/v2/file/<SIP-UUID>/pointer_file/\
                   ?username=<SS-USERNAME>&api_key=<SS-API-KEY>
+
+        If ``expected_content`` is provided, retry until the pointer file
+        contains it. This handles pointer files that are temporarily stale
+        after re-ingest.
         """
         payload = {"username": self.ss_username, "api_key": ss_api_key}
         url = f"{self.ss_url}api/v2/file/{sip_uuid}/pointer_file/"
@@ -196,7 +200,25 @@ class ArchivematicaAPIAbility(base.Base):
             r = requests.get(url, params=payload, stream=True)
             if r.ok:
                 _save_download(r, pointer_file_path)
-                return pointer_file_path
+                with open(pointer_file_path) as pointer_file:
+                    if (
+                        expected_content is None
+                        or expected_content in pointer_file.read()
+                    ):
+                        return pointer_file_path
+                if attempt < max_attempts:
+                    logger.warning(
+                        "Trying again to download AIP %s pointer file because"
+                        " it does not contain the expected content",
+                        sip_uuid,
+                    )
+                    attempt += 1
+                    time.sleep(self.optimistic_wait)
+                else:
+                    raise ArchivematicaAPIAbilityError(
+                        f"AIP {sip_uuid} pointer file does not contain the"
+                        " expected content"
+                    )
             elif r.status_code in (404, 500) and attempt < max_attempts:
                 logger.warning(
                     "Trying again to download AIP %s pointer file via GET"

--- a/amuser/am_browser_ingest_ability.py
+++ b/amuser/am_browser_ingest_ability.py
@@ -62,7 +62,13 @@ class ArchivematicaBrowserIngestAbility(selenium_ability.ArchivematicaSeleniumAb
         logger.info("Got SIP UUID %s", sip_uuid)
         return sip_uuid
 
-    @tenacity.retry(stop=tenacity.stop_after_attempt(20), wait=tenacity.wait_fixed(15))
+    @tenacity.retry(
+        stop=tenacity.stop_after_attempt(20),
+        wait=tenacity.wait_exponential(
+            multiplier=c.MICRO_WAIT,
+            max=c.OPTIMISTIC_WAIT,
+        ),
+    )
     def get_mets_via_api(self, transfer_name, sip_uuid=None, parse_xml=True):
         """Return METS once stored in an AIP."""
         if not sip_uuid:

--- a/features/black_box/checksum.feature
+++ b/features/black_box/checksum.feature
@@ -2,12 +2,12 @@
 Feature: Alma wants to verify checksums transmitted with a transfer to ensure that the transfer contents haven't been corrupted.
 
   Scenario: External metadata checksums are verified
-    Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV"
+    Given a "standard" transfer-only transfer located in "SampleTransfers/DemoTransferCSV"
     When the transfer compliance is verified
     Then the "Verify metadata directory checksums" job completes successfully
 
   Scenario: External metadata checksums are not verified
-    Given a "standard" transfer type located in "TestTransfers/fixityCheckShouldFail"
+    Given a "standard" transfer-only transfer located in "TestTransfers/fixityCheckShouldFail"
     When the transfer compliance is verified
     Then the "Verify metadata directory checksums" job fails
     And the "Failed transfer" microservice is executed

--- a/features/black_box/extract-package.feature
+++ b/features/black_box/extract-package.feature
@@ -2,7 +2,7 @@
 Feature: Alma wants package files included in the transfer to be extracted.
 
   Scenario: packages are extracted successfully
-    Given a "standard" transfer type located in "SampleTransfers/OfficeDocs"
+    Given a "standard" transfer-only transfer located in "SampleTransfers/OfficeDocs"
     When the transfer compliance is verified
     Then the "Extract contents from compressed archives" job completes successfully
     And the "Change extracted objects' file and directory names" job completes successfully
@@ -12,7 +12,7 @@ Feature: Alma wants package files included in the transfer to be extracted.
     And the "Determine if transfer still contains packages" job completes successfully
 
   Scenario: packages are not extracted successfully
-    Given a "standard" transfer type located in "TestTransfers/broken_package_format_types"
+    Given a "standard" transfer-only transfer located in "TestTransfers/broken_package_format_types"
     When the transfer compliance is verified
     Then the "Extract contents from compressed archives" job fails
     And the "Failed transfer" microservice is executed

--- a/features/black_box/reingest-aip.feature
+++ b/features/black_box/reingest-aip.feature
@@ -22,6 +22,7 @@ Feature: Alma wants to be able to re-ingest an AIP and have the reingest recorde
     And there is a current and a superseded techMD for each original object
     And there is a sourceMD containing a BagIt mdWrap in the reingested AIP METS
 
+  @requires-browser
   Scenario: Metadata only reingest without error
     Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV"
     And a processing configuration for metadata only reingests
@@ -37,6 +38,7 @@ Feature: Alma wants to be able to re-ingest an AIP and have the reingest recorde
     And the "metadata.csv" file is in the reingest metadata directory
     And every file in the reingested metadata.csv file has two dmdSecs with the original and updated metadata
 
+  @requires-browser
   Scenario: Partial reingest without error
     Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV"
     And a processing configuration for partial reingests
@@ -49,6 +51,7 @@ Feature: Alma wants to be able to re-ingest an AIP and have the reingest recorde
     And the DIP is downloaded
     And the DIP contains access copies for each original object in the transfer
 
+  @requires-browser
   Scenario: Multiple Re-ingest for uncompressed AIPs
     Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV"
     #

--- a/features/black_box/virus.feature
+++ b/features/black_box/virus.feature
@@ -2,12 +2,12 @@
 Feature: Alma wants to ensure that virus scanning in Archivematica works correctly to ensure transfers pass when they have no viruses, and transfers fail when they contain viruses.
 
   Scenario: Virus checks for a transfer pass
-    Given a "standard" transfer type located in "SampleTransfers/DemoTransferCSV"
+    Given a "standard" transfer-only transfer located in "SampleTransfers/DemoTransferCSV"
     When the transfer compliance is verified
     Then the "Scan for viruses in directories" job completes successfully
 
   Scenario: Virus checks for a transfer fail
-    Given a "standard" transfer type located in "TestTransfers/virusTests"
+    Given a "standard" transfer-only transfer located in "TestTransfers/virusTests"
     When the transfer compliance is verified
     Then the "Scan for viruses in directories" job fails
     And the "Failed transfer" microservice is executed

--- a/features/environment.py
+++ b/features/environment.py
@@ -41,6 +41,7 @@ SS_API_CONFIG_KEY = "storage_service"
 TRANSFER_SOURCE_PATH = "vagrant/archivematica-sampledata/TestTransfers/acceptance-tests"
 HOME = ""
 DRIVER_NAME = "Chrome"
+BROWSER_REQUIRED_TAG = "requires-browser"
 AUTOMATION_TOOLS_PATH = "/etc/archivematica/automation-tools"
 # Set these constants if the AM client should be able to gain SSH access to the
 # server where AM is being served. This is needed in order to scp server files
@@ -158,7 +159,11 @@ def before_scenario(context, scenario):
     context.utils = utils
     if "driver_name" in userdata:
         context.am_user = get_am_user(userdata)
-        context.am_user.browser.set_up()
+        if (
+            "black-box" not in scenario.effective_tags
+            or BROWSER_REQUIRED_TAG in scenario.effective_tags
+        ):
+            context.am_user.browser.set_up()
     context.TRANSFER_SOURCE_PATH = userdata.get(
         "transfer_source_path", TRANSFER_SOURCE_PATH
     )
@@ -198,7 +203,10 @@ def after_scenario(context, scenario):
         " than that of the AIP on the second one."
     ):
         context.am_user.docker.recreate_archivematica(capture_output=True)
-    if getattr(context, "am_user", None) is not None:
+    if (
+        getattr(context, "am_user", None) is not None
+        and context.am_user.browser.driver is not None
+    ):
         context.am_user.browser.tear_down()
 
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -188,6 +188,9 @@ def before_scenario(context, scenario):
 
 def after_scenario(context, scenario):
     """Close all browser windows/Selenium drivers."""
+    transfer = getattr(context, "current_transfer", {})
+    if transfer.get("transfer_only") and transfer.get("status") == "USER_INPUT":
+        context.am_user.api.reject_transfer(transfer["transfer_uuid"])
     # In the following scenario, we've created a weird FPR rule. Here we put
     # things back as they were: make access .mov files normalize to .mp4
     if scenario.name == (

--- a/features/steps/black_box_steps.py
+++ b/features/steps/black_box_steps.py
@@ -155,6 +155,20 @@ def step_impl(context):
     context.current_transfer["sip_uuid"] = sip_uuid
 
 
+@given('a "{transfer_type}" transfer-only transfer located in "{sample_transfer_path}"')
+def step_impl(context, transfer_type, sample_transfer_path):
+    if not getattr(context.config, "transfer_only_processing_config_ready", False):
+        context.am_user.api.install_transfer_only_processing_config(
+            utils.TRANSFER_ONLY_PROCESSING_CONFIG
+        )
+        context.config.transfer_only_processing_config_ready = True
+    context.current_transfer = utils.create_transfer_only_sample_transfer(
+        context.api_clients_config,
+        sample_transfer_path,
+        transfer_type=transfer_type,
+    )
+
+
 @given("a processing configuration for metadata only reingests for uncompressed AIPs")
 def step_impl(context):
     context.execute_steps(

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -245,7 +245,6 @@ def _appear_in_storage(context):
     ingest = utils.wait_for_ingest(context.api_clients_config, uuid_val)
     assert ingest["status"] != "FAILED", f"Ingest {uuid_val} failed"
     context.am_user.browser.wait_for_aip_in_archival_storage(uuid_val)
-    time.sleep(context.am_user.pessimistic_wait)
 
 
 @when("the user waits for the AIP to appear in archival storage")

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -315,17 +315,20 @@ def step_impl(context):
 use_step_matcher("parse")
 
 
+def _download_aip_pointer_file(context, aip_uuid):
+    expected_content = getattr(context.scenario, "new_key_fingerprint", None)
+    return context.am_user.api.download_aip_pointer_file(
+        aip_uuid,
+        context.am_user.browser.ss_api_key,
+        expected_content=expected_content,
+    )
+
+
 @when("the user downloads the AIP pointer file")
 def step_impl(context):
     uuid_val = utils.get_uuid_val(context, "sip")
-    # For some reason, it is necessary to pause a moment before downloading the
-    # AIP pointer file because otherwise, e.g., after a re-ingest, it can be
-    # out of date. See @reencrypt-different-key.
-    time.sleep(context.am_user.pessimistic_wait)
-    context.scenario.aip_pointer_path = app = (
-        context.am_user.api.download_aip_pointer_file(
-            uuid_val, context.am_user.browser.ss_api_key
-        )
+    context.scenario.aip_pointer_path = app = _download_aip_pointer_file(
+        context, uuid_val
     )
     logger.info("downloaded AIP pointer file for AIP %s to %s", uuid_val, app)
 
@@ -335,13 +338,10 @@ def step_impl(context, aip_description):
     aip_attr = utils.aip_descr_to_attr(aip_description)
     aip_ptr_attr = utils.aip_descr_to_ptr_attr(aip_description)
     aip_uuid = getattr(context.scenario, aip_attr)
-    time.sleep(context.am_user.pessimistic_wait)
     setattr(
         context.scenario,
         aip_ptr_attr,
-        context.am_user.api.download_aip_pointer_file(
-            aip_uuid, context.am_user.browser.ss_api_key
-        ),
+        _download_aip_pointer_file(context, aip_uuid),
     )
     logger.info(
         "downloaded AIP pointer file for %s AIP %s to %s",

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -21,6 +21,9 @@ from selenium.webdriver.support.ui import Select
 
 logger = logging.getLogger("amauat.steps.utils")
 
+TERMINAL_UNIT_STATUSES = ("COMPLETE", "FAILED")
+FAST_UNIT_STATUS_POLL_ATTEMPTS = 3
+
 
 class ArchivematicaStepsError(Exception):
     pass
@@ -534,15 +537,23 @@ def start_reingest(
     return reingest_uuid
 
 
+def _get_unit_status_endpoint(api_clients_config, unit_uuid, unit="transfer"):
+    am = configure_am_client(api_clients_config[AM_API_CONFIG_KEY])
+    am.transfer_uuid = unit_uuid
+    am.sip_uuid = unit_uuid
+    return getattr(am, f"get_{unit}_status")
+
+
+def _check_unit_status_once(api_clients_config, unit_uuid, unit="transfer"):
+    return _get_unit_status_endpoint(api_clients_config, unit_uuid, unit)()
+
+
 def check_unit_status(api_clients_config, unit_uuid, unit="transfer"):
     """
     Get the status of a transfer or an ingest.
     """
-    am = configure_am_client(api_clients_config[AM_API_CONFIG_KEY])
-    am.transfer_uuid = unit_uuid
-    am.sip_uuid = unit_uuid
     return call_api_endpoint(
-        endpoint=getattr(am, f"get_{unit}_status"),
+        endpoint=_get_unit_status_endpoint(api_clients_config, unit_uuid, unit),
         warning_message="Cannot check unit status",
         error_message="Cannot check unit status",
     )
@@ -762,17 +773,43 @@ def start_sample_transfer(
         raise AssertionError(f"Error starting transfer: {err}")
 
 
+def _is_terminal_unit_status(response):
+    return (
+        not is_invalid_api_response(response)
+        and response.get("status") in TERMINAL_UNIT_STATUSES
+    )
+
+
+def _wait_for_unit_status(api_clients_config, unit_uuid, unit):
+    # Probe a few times while the unit is expected to finish quickly. These calls are
+    # deliberately best-effort: the status endpoint may not be ready immediately
+    # after a unit is created.
+    for _ in range(FAST_UNIT_STATUS_POLL_ATTEMPTS):
+        try:
+            response = _check_unit_status_once(api_clients_config, unit_uuid, unit)
+            if _is_terminal_unit_status(response):
+                return response
+        except Exception:
+            logger.debug(
+                "Ignoring an unsuccessful early %s status probe for %s",
+                unit,
+                unit_uuid,
+                exc_info=True,
+            )
+        time.sleep(environment.OPTIMISTIC_WAIT)
+
+    # From this point onward, retain the status endpoint's existing transient-error
+    # retries while continuing to poll at the faster cadence.
+    while True:
+        response = check_unit_status(api_clients_config, unit_uuid, unit)
+        if _is_terminal_unit_status(response):
+            return response
+        time.sleep(environment.OPTIMISTIC_WAIT)
+
+
 def wait_for_transfer(api_clients_config, transfer_uuid):
-    status = None
-    resp = None
     try:
-        while status not in ("COMPLETE", "FAILED"):
-            time.sleep(environment.MEDIUM_WAIT)
-            resp = check_unit_status(api_clients_config, transfer_uuid, "transfer")
-            if isinstance(resp, int) or resp is None:
-                continue
-            status = resp.get("status")
-        return resp
+        return _wait_for_unit_status(api_clients_config, transfer_uuid, "transfer")
     except environment.EnvironmentError as err:
         raise AssertionError(
             f"Error checking transfer (uuid: {transfer_uuid}) status: {err}"
@@ -780,16 +817,8 @@ def wait_for_transfer(api_clients_config, transfer_uuid):
 
 
 def wait_for_ingest(api_clients_config, sip_uuid):
-    status = None
-    resp = None
     try:
-        while status not in ("COMPLETE", "FAILED"):
-            time.sleep(environment.MEDIUM_WAIT)
-            resp = check_unit_status(api_clients_config, sip_uuid, unit="ingest")
-            if isinstance(resp, int) or resp is None:
-                continue
-            status = resp.get("status")
-        return resp
+        return _wait_for_unit_status(api_clients_config, sip_uuid, "ingest")
     except environment.EnvironmentError as err:
         raise AssertionError(f"Error checking ingest (uuid: {sip_uuid}) status: {err}")
 

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -22,7 +22,9 @@ from selenium.webdriver.support.ui import Select
 logger = logging.getLogger("amauat.steps.utils")
 
 TERMINAL_UNIT_STATUSES = ("COMPLETE", "FAILED")
+TRANSFER_ONLY_UNIT_STATUSES = ("USER_INPUT", "FAILED")
 FAST_UNIT_STATUS_POLL_ATTEMPTS = 3
+TRANSFER_ONLY_PROCESSING_CONFIG = "transfer_only"
 
 
 class ArchivematicaStepsError(Exception):
@@ -773,21 +775,26 @@ def start_sample_transfer(
         raise AssertionError(f"Error starting transfer: {err}")
 
 
-def _is_terminal_unit_status(response):
+def _is_terminal_unit_status(response, terminal_statuses=TERMINAL_UNIT_STATUSES):
     return (
         not is_invalid_api_response(response)
-        and response.get("status") in TERMINAL_UNIT_STATUSES
+        and response.get("status") in terminal_statuses
     )
 
 
-def _wait_for_unit_status(api_clients_config, unit_uuid, unit):
+def _wait_for_unit_status(
+    api_clients_config,
+    unit_uuid,
+    unit,
+    terminal_statuses=TERMINAL_UNIT_STATUSES,
+):
     # Probe a few times while the unit is expected to finish quickly. These calls are
     # deliberately best-effort: the status endpoint may not be ready immediately
     # after a unit is created.
     for _ in range(FAST_UNIT_STATUS_POLL_ATTEMPTS):
         try:
             response = _check_unit_status_once(api_clients_config, unit_uuid, unit)
-            if _is_terminal_unit_status(response):
+            if _is_terminal_unit_status(response, terminal_statuses):
                 return response
         except Exception:
             logger.debug(
@@ -802,14 +809,23 @@ def _wait_for_unit_status(api_clients_config, unit_uuid, unit):
     # retries while continuing to poll at the faster cadence.
     while True:
         response = check_unit_status(api_clients_config, unit_uuid, unit)
-        if _is_terminal_unit_status(response):
+        if _is_terminal_unit_status(response, terminal_statuses):
             return response
         time.sleep(environment.OPTIMISTIC_WAIT)
 
 
-def wait_for_transfer(api_clients_config, transfer_uuid):
+def wait_for_transfer(
+    api_clients_config,
+    transfer_uuid,
+    terminal_statuses=TERMINAL_UNIT_STATUSES,
+):
     try:
-        return _wait_for_unit_status(api_clients_config, transfer_uuid, "transfer")
+        return _wait_for_unit_status(
+            api_clients_config,
+            transfer_uuid,
+            "transfer",
+            terminal_statuses,
+        )
     except environment.EnvironmentError as err:
         raise AssertionError(
             f"Error checking transfer (uuid: {transfer_uuid}) status: {err}"
@@ -871,6 +887,31 @@ def create_sample_transfer(
         transfer["transfer_uuid"],
         transfer["extracted_aip_dir"],
     )
+    return transfer
+
+
+def create_transfer_only_sample_transfer(
+    api_clients_config, sample_transfer_path, transfer_type="standard"
+):
+    transfer = start_sample_transfer(
+        api_clients_config,
+        sample_transfer_path,
+        transfer_type=transfer_type,
+        processing_config=TRANSFER_ONLY_PROCESSING_CONFIG,
+    )
+    response = wait_for_transfer(
+        api_clients_config,
+        transfer["transfer_uuid"],
+        terminal_statuses=TRANSFER_ONLY_UNIT_STATUSES,
+    )
+    transfer["status"] = response["status"]
+    transfer["microservice"] = response["microservice"]
+    transfer["transfer_only"] = True
+    if response["status"] == "USER_INPUT":
+        assert response["microservice"] == "Create SIP(s)", (
+            "Transfer stopped at an unexpected decision point: "
+            f"{response['microservice']}"
+        )
     return transfer
 
 

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -363,7 +363,11 @@ def call_api_endpoint(
             if attempts == max_attempts:
                 raise environment.EnvironmentError(error_message)
             logger.warning(warning_message)
-            time.sleep(environment.OPTIMISTIC_WAIT * attempts)
+            retry_wait = min(
+                environment.MICRO_WAIT * 2 ** (attempts - 1),
+                environment.OPTIMISTIC_WAIT,
+            )
+            time.sleep(retry_wait)
     return response
 
 


### PR DESCRIPTION
This PR speeds up AMAUAT by polling transfer and ingest status more frequently, shortening API retry delays, skipping Firefox for API-only black-box scenarios, stopping transfer-only scenarios before ingest and AIP creation, and replacing fixed AIP and pointer-file waits with readiness checks.

Compared with the median of the five most recent successful pre-change runs, the optimized run reduced cumulative Behave execution from **1h09m17s to 52m13s** (**17m04s, or 25%**) and cumulative AMAUAT step time from **1h24m20s to 1h08m30s** (**15m50s, or 19%**); black-box Behave time fell from **20m52s to 17m03s** (**18%**), and the longest matrix job fell from **30m30s to 25m12s** (**17%**).

These changes affect AMAUAT waiting and scenario setup, but do not optimize repository checkout, image builds, service startup, runner allocation, or Archivematica itself, which is why cumulative whole-job runner time improved by only **7%** and some individual job totals remained flat or increased.

- Poll transfer and ingest status every four seconds.
- Use shorter, capped API retry delays.
- Skip Firefox for API-only black-box scenarios.
- Stop checksum, virus, and extraction tests before ingest and AIP creation.
- Remove a redundant 20-second wait after AIP storage.
- Poll pointer files for updated content instead of waiting 20 seconds.